### PR TITLE
feat(api): implement database schemas for postgresql and mongodb

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -9,3 +9,5 @@ DB_PORT=5432
 DB_USER=root
 DB_PASSWORD=root
 DB_DATABASE=app
+MONGO_URI=mongodb://localhost:27017
+MONGO_DATABASE=althea_images

--- a/apps/api/app/models/address.ts
+++ b/apps/api/app/models/address.ts
@@ -1,7 +1,9 @@
 import { DateTime } from 'luxon'
-import { BaseModel, column, belongsTo } from '@adonisjs/lucid/orm'
+import { BaseModel, belongsTo, column } from '@adonisjs/lucid/orm'
 import type { BelongsTo } from '@adonisjs/lucid/types/relations'
 import User from '#models/user'
+
+export type AddressType = 'billing' | 'shipping'
 
 export default class Address extends BaseModel {
   @column({ isPrimary: true })
@@ -11,13 +13,22 @@ export default class Address extends BaseModel {
   declare userId: number
 
   @column()
-  declare type: 'billing' | 'shipping'
+  declare type: AddressType
+
+  @column()
+  declare fullName: string
 
   @column()
   declare street: string
 
   @column()
+  declare line2: string | null
+
+  @column()
   declare city: string
+
+  @column()
+  declare region: string | null
 
   @column()
   declare postalCode: string
@@ -26,14 +37,17 @@ export default class Address extends BaseModel {
   declare country: string
 
   @column()
-  declare isDefault: boolean
+  declare phone: string | null
 
-  @belongsTo(() => User)
-  declare user: BelongsTo<typeof User>
+  @column()
+  declare isDefault: boolean
 
   @column.dateTime({ autoCreate: true })
   declare createdAt: DateTime
 
   @column.dateTime({ autoCreate: true, autoUpdate: true })
-  declare updatedAt: DateTime
+  declare updatedAt: DateTime | null
+
+  @belongsTo(() => User)
+  declare user: BelongsTo<typeof User>
 }

--- a/apps/api/app/models/address.ts
+++ b/apps/api/app/models/address.ts
@@ -1,0 +1,39 @@
+import { DateTime } from 'luxon'
+import { BaseModel, column, belongsTo } from '@adonisjs/lucid/orm'
+import type { BelongsTo } from '@adonisjs/lucid/types/relations'
+import User from '#models/user'
+
+export default class Address extends BaseModel {
+  @column({ isPrimary: true })
+  declare id: number
+
+  @column()
+  declare userId: number
+
+  @column()
+  declare type: 'billing' | 'shipping'
+
+  @column()
+  declare street: string
+
+  @column()
+  declare city: string
+
+  @column()
+  declare postalCode: string
+
+  @column()
+  declare country: string
+
+  @column()
+  declare isDefault: boolean
+
+  @belongsTo(() => User)
+  declare user: BelongsTo<typeof User>
+
+  @column.dateTime({ autoCreate: true })
+  declare createdAt: DateTime
+
+  @column.dateTime({ autoCreate: true, autoUpdate: true })
+  declare updatedAt: DateTime
+}

--- a/apps/api/app/models/category.ts
+++ b/apps/api/app/models/category.ts
@@ -1,0 +1,30 @@
+import { DateTime } from 'luxon'
+import { BaseModel, column, hasMany } from '@adonisjs/lucid/orm'
+import type { HasMany } from '@adonisjs/lucid/types/relations'
+import Product from '#models/product'
+
+export default class Category extends BaseModel {
+  @column({ isPrimary: true })
+  declare id: number
+
+  @column()
+  declare name: string
+
+  @column()
+  declare slug: string
+
+  @column()
+  declare description: string | null
+
+  @column()
+  declare parentId: number | null
+
+  @hasMany(() => Product)
+  declare products: HasMany<typeof Product>
+
+  @column.dateTime({ autoCreate: true })
+  declare createdAt: DateTime
+
+  @column.dateTime({ autoCreate: true, autoUpdate: true })
+  declare updatedAt: DateTime
+}

--- a/apps/api/app/models/category.ts
+++ b/apps/api/app/models/category.ts
@@ -1,6 +1,6 @@
 import { DateTime } from 'luxon'
-import { BaseModel, column, hasMany } from '@adonisjs/lucid/orm'
-import type { HasMany } from '@adonisjs/lucid/types/relations'
+import { BaseModel, belongsTo, column, hasMany } from '@adonisjs/lucid/orm'
+import type { BelongsTo, HasMany } from '@adonisjs/lucid/types/relations'
 import Product from '#models/product'
 
 export default class Category extends BaseModel {
@@ -19,12 +19,24 @@ export default class Category extends BaseModel {
   @column()
   declare parentId: number | null
 
-  @hasMany(() => Product)
-  declare products: HasMany<typeof Product>
+  @column()
+  declare imagePath: string | null
+
+  @column()
+  declare position: number
 
   @column.dateTime({ autoCreate: true })
   declare createdAt: DateTime
 
   @column.dateTime({ autoCreate: true, autoUpdate: true })
-  declare updatedAt: DateTime
+  declare updatedAt: DateTime | null
+
+  @belongsTo(() => Category, { foreignKey: 'parentId' })
+  declare parent: BelongsTo<typeof Category>
+
+  @hasMany(() => Category, { foreignKey: 'parentId' })
+  declare children: HasMany<typeof Category>
+
+  @hasMany(() => Product)
+  declare products: HasMany<typeof Product>
 }

--- a/apps/api/app/models/contact_message.ts
+++ b/apps/api/app/models/contact_message.ts
@@ -1,0 +1,28 @@
+import { DateTime } from 'luxon'
+import { BaseModel, column } from '@adonisjs/lucid/orm'
+
+export default class ContactMessage extends BaseModel {
+  @column({ isPrimary: true })
+  declare id: number
+
+  @column()
+  declare name: string
+
+  @column()
+  declare email: string
+
+  @column()
+  declare subject: string
+
+  @column()
+  declare message: string
+
+  @column()
+  declare isRead: boolean
+
+  @column.dateTime({ autoCreate: true })
+  declare createdAt: DateTime
+
+  @column.dateTime({ autoCreate: true, autoUpdate: true })
+  declare updatedAt: DateTime
+}

--- a/apps/api/app/models/contact_message.ts
+++ b/apps/api/app/models/contact_message.ts
@@ -1,9 +1,14 @@
 import { DateTime } from 'luxon'
-import { BaseModel, column } from '@adonisjs/lucid/orm'
+import { BaseModel, belongsTo, column } from '@adonisjs/lucid/orm'
+import type { BelongsTo } from '@adonisjs/lucid/types/relations'
+import User from '#models/user'
 
 export default class ContactMessage extends BaseModel {
   @column({ isPrimary: true })
   declare id: number
+
+  @column()
+  declare userId: number | null
 
   @column()
   declare name: string
@@ -24,5 +29,8 @@ export default class ContactMessage extends BaseModel {
   declare createdAt: DateTime
 
   @column.dateTime({ autoCreate: true, autoUpdate: true })
-  declare updatedAt: DateTime
+  declare updatedAt: DateTime | null
+
+  @belongsTo(() => User)
+  declare user: BelongsTo<typeof User>
 }

--- a/apps/api/app/models/credit_note.ts
+++ b/apps/api/app/models/credit_note.ts
@@ -1,0 +1,33 @@
+import { DateTime } from 'luxon'
+import { BaseModel, column, belongsTo } from '@adonisjs/lucid/orm'
+import type { BelongsTo } from '@adonisjs/lucid/types/relations'
+import Invoice from '#models/invoice'
+
+export default class CreditNote extends BaseModel {
+  @column({ isPrimary: true })
+  declare id: number
+
+  @column()
+  declare invoiceId: number
+
+  @column()
+  declare creditNoteNumber: string
+
+  @column()
+  declare amount: number
+
+  @column()
+  declare reason: string
+
+  @column.dateTime()
+  declare issuedAt: DateTime
+
+  @belongsTo(() => Invoice)
+  declare invoice: BelongsTo<typeof Invoice>
+
+  @column.dateTime({ autoCreate: true })
+  declare createdAt: DateTime
+
+  @column.dateTime({ autoCreate: true, autoUpdate: true })
+  declare updatedAt: DateTime
+}

--- a/apps/api/app/models/credit_note.ts
+++ b/apps/api/app/models/credit_note.ts
@@ -1,5 +1,5 @@
 import { DateTime } from 'luxon'
-import { BaseModel, column, belongsTo } from '@adonisjs/lucid/orm'
+import { BaseModel, belongsTo, column } from '@adonisjs/lucid/orm'
 import type { BelongsTo } from '@adonisjs/lucid/types/relations'
 import Invoice from '#models/invoice'
 
@@ -17,17 +17,20 @@ export default class CreditNote extends BaseModel {
   declare amount: number
 
   @column()
-  declare reason: string
+  declare reason: string | null
+
+  @column()
+  declare pdfPath: string | null
 
   @column.dateTime()
   declare issuedAt: DateTime
-
-  @belongsTo(() => Invoice)
-  declare invoice: BelongsTo<typeof Invoice>
 
   @column.dateTime({ autoCreate: true })
   declare createdAt: DateTime
 
   @column.dateTime({ autoCreate: true, autoUpdate: true })
-  declare updatedAt: DateTime
+  declare updatedAt: DateTime | null
+
+  @belongsTo(() => Invoice)
+  declare invoice: BelongsTo<typeof Invoice>
 }

--- a/apps/api/app/models/invoice.ts
+++ b/apps/api/app/models/invoice.ts
@@ -1,0 +1,40 @@
+import { DateTime } from 'luxon'
+import { BaseModel, column, belongsTo, hasMany } from '@adonisjs/lucid/orm'
+import type { BelongsTo, HasMany } from '@adonisjs/lucid/types/relations'
+import Order from '#models/order'
+import CreditNote from '#models/credit_note'
+
+export default class Invoice extends BaseModel {
+  @column({ isPrimary: true })
+  declare id: number
+
+  @column()
+  declare orderId: number
+
+  @column()
+  declare invoiceNumber: string
+
+  @column()
+  declare subtotal: number
+
+  @column()
+  declare tax: number
+
+  @column()
+  declare total: number
+
+  @column.dateTime()
+  declare issuedAt: DateTime
+
+  @belongsTo(() => Order)
+  declare order: BelongsTo<typeof Order>
+
+  @hasMany(() => CreditNote)
+  declare creditNotes: HasMany<typeof CreditNote>
+
+  @column.dateTime({ autoCreate: true })
+  declare createdAt: DateTime
+
+  @column.dateTime({ autoCreate: true, autoUpdate: true })
+  declare updatedAt: DateTime
+}

--- a/apps/api/app/models/invoice.ts
+++ b/apps/api/app/models/invoice.ts
@@ -1,5 +1,5 @@
 import { DateTime } from 'luxon'
-import { BaseModel, column, belongsTo, hasMany } from '@adonisjs/lucid/orm'
+import { BaseModel, belongsTo, column, hasMany } from '@adonisjs/lucid/orm'
 import type { BelongsTo, HasMany } from '@adonisjs/lucid/types/relations'
 import Order from '#models/order'
 import CreditNote from '#models/credit_note'
@@ -23,18 +23,21 @@ export default class Invoice extends BaseModel {
   @column()
   declare total: number
 
+  @column()
+  declare pdfPath: string | null
+
   @column.dateTime()
   declare issuedAt: DateTime
+
+  @column.dateTime({ autoCreate: true })
+  declare createdAt: DateTime
+
+  @column.dateTime({ autoCreate: true, autoUpdate: true })
+  declare updatedAt: DateTime | null
 
   @belongsTo(() => Order)
   declare order: BelongsTo<typeof Order>
 
   @hasMany(() => CreditNote)
   declare creditNotes: HasMany<typeof CreditNote>
-
-  @column.dateTime({ autoCreate: true })
-  declare createdAt: DateTime
-
-  @column.dateTime({ autoCreate: true, autoUpdate: true })
-  declare updatedAt: DateTime
 }

--- a/apps/api/app/models/order.ts
+++ b/apps/api/app/models/order.ts
@@ -1,0 +1,53 @@
+import { DateTime } from 'luxon'
+import { BaseModel, column, belongsTo, hasMany } from '@adonisjs/lucid/orm'
+import type { BelongsTo, HasMany } from '@adonisjs/lucid/types/relations'
+import User from '#models/user'
+import Address from '#models/address'
+import OrderItem from '#models/order_item'
+
+export default class Order extends BaseModel {
+  @column({ isPrimary: true })
+  declare id: number
+
+  @column()
+  declare userId: number
+
+  @column()
+  declare status: 'pending' | 'processing' | 'shipped' | 'delivered' | 'cancelled'
+
+  @column()
+  declare subtotal: number
+
+  @column()
+  declare tax: number
+
+  @column()
+  declare shippingCost: number
+
+  @column()
+  declare total: number
+
+  @column()
+  declare shippingAddressId: number
+
+  @column()
+  declare billingAddressId: number
+
+  @belongsTo(() => User)
+  declare user: BelongsTo<typeof User>
+
+  @belongsTo(() => Address, { foreignKey: 'shippingAddressId' })
+  declare shippingAddress: BelongsTo<typeof Address>
+
+  @belongsTo(() => Address, { foreignKey: 'billingAddressId' })
+  declare billingAddress: BelongsTo<typeof Address>
+
+  @hasMany(() => OrderItem)
+  declare items: HasMany<typeof OrderItem>
+
+  @column.dateTime({ autoCreate: true })
+  declare createdAt: DateTime
+
+  @column.dateTime({ autoCreate: true, autoUpdate: true })
+  declare updatedAt: DateTime
+}

--- a/apps/api/app/models/order.ts
+++ b/apps/api/app/models/order.ts
@@ -1,9 +1,20 @@
 import { DateTime } from 'luxon'
-import { BaseModel, column, belongsTo, hasMany } from '@adonisjs/lucid/orm'
-import type { BelongsTo, HasMany } from '@adonisjs/lucid/types/relations'
+import { BaseModel, belongsTo, column, hasMany, hasOne } from '@adonisjs/lucid/orm'
+import type { BelongsTo, HasMany, HasOne } from '@adonisjs/lucid/types/relations'
 import User from '#models/user'
 import Address from '#models/address'
 import OrderItem from '#models/order_item'
+import PaymentMethod from '#models/payment_method'
+import Invoice from '#models/invoice'
+
+export type OrderStatus =
+  | 'pending'
+  | 'paid'
+  | 'processing'
+  | 'shipped'
+  | 'delivered'
+  | 'cancelled'
+  | 'refunded'
 
 export default class Order extends BaseModel {
   @column({ isPrimary: true })
@@ -13,7 +24,7 @@ export default class Order extends BaseModel {
   declare userId: number
 
   @column()
-  declare status: 'pending' | 'processing' | 'shipped' | 'delivered' | 'cancelled'
+  declare status: OrderStatus
 
   @column()
   declare subtotal: number
@@ -28,10 +39,25 @@ export default class Order extends BaseModel {
   declare total: number
 
   @column()
-  declare shippingAddressId: number
+  declare shippingAddressId: number | null
 
   @column()
-  declare billingAddressId: number
+  declare billingAddressId: number | null
+
+  @column()
+  declare paymentMethodId: number | null
+
+  @column()
+  declare stripePaymentIntentId: string | null
+
+  @column.dateTime()
+  declare placedAt: DateTime | null
+
+  @column.dateTime({ autoCreate: true })
+  declare createdAt: DateTime
+
+  @column.dateTime({ autoCreate: true, autoUpdate: true })
+  declare updatedAt: DateTime | null
 
   @belongsTo(() => User)
   declare user: BelongsTo<typeof User>
@@ -42,12 +68,12 @@ export default class Order extends BaseModel {
   @belongsTo(() => Address, { foreignKey: 'billingAddressId' })
   declare billingAddress: BelongsTo<typeof Address>
 
+  @belongsTo(() => PaymentMethod)
+  declare paymentMethod: BelongsTo<typeof PaymentMethod>
+
   @hasMany(() => OrderItem)
   declare items: HasMany<typeof OrderItem>
 
-  @column.dateTime({ autoCreate: true })
-  declare createdAt: DateTime
-
-  @column.dateTime({ autoCreate: true, autoUpdate: true })
-  declare updatedAt: DateTime
+  @hasOne(() => Invoice)
+  declare invoice: HasOne<typeof Invoice>
 }

--- a/apps/api/app/models/order_item.ts
+++ b/apps/api/app/models/order_item.ts
@@ -1,0 +1,37 @@
+import { DateTime } from 'luxon'
+import { BaseModel, column, belongsTo } from '@adonisjs/lucid/orm'
+import type { BelongsTo } from '@adonisjs/lucid/types/relations'
+import Order from '#models/order'
+import Product from '#models/product'
+
+export default class OrderItem extends BaseModel {
+  @column({ isPrimary: true })
+  declare id: number
+
+  @column()
+  declare orderId: number
+
+  @column()
+  declare productId: number
+
+  @column()
+  declare quantity: number
+
+  @column()
+  declare unitPrice: number
+
+  @column()
+  declare total: number
+
+  @belongsTo(() => Order)
+  declare order: BelongsTo<typeof Order>
+
+  @belongsTo(() => Product)
+  declare product: BelongsTo<typeof Product>
+
+  @column.dateTime({ autoCreate: true })
+  declare createdAt: DateTime
+
+  @column.dateTime({ autoCreate: true, autoUpdate: true })
+  declare updatedAt: DateTime
+}

--- a/apps/api/app/models/order_item.ts
+++ b/apps/api/app/models/order_item.ts
@@ -1,5 +1,5 @@
 import { DateTime } from 'luxon'
-import { BaseModel, column, belongsTo } from '@adonisjs/lucid/orm'
+import { BaseModel, belongsTo, column } from '@adonisjs/lucid/orm'
 import type { BelongsTo } from '@adonisjs/lucid/types/relations'
 import Order from '#models/order'
 import Product from '#models/product'
@@ -12,7 +12,10 @@ export default class OrderItem extends BaseModel {
   declare orderId: number
 
   @column()
-  declare productId: number
+  declare productId: number | null
+
+  @column()
+  declare productName: string
 
   @column()
   declare quantity: number
@@ -23,15 +26,15 @@ export default class OrderItem extends BaseModel {
   @column()
   declare total: number
 
+  @column.dateTime({ autoCreate: true })
+  declare createdAt: DateTime
+
+  @column.dateTime({ autoCreate: true, autoUpdate: true })
+  declare updatedAt: DateTime | null
+
   @belongsTo(() => Order)
   declare order: BelongsTo<typeof Order>
 
   @belongsTo(() => Product)
   declare product: BelongsTo<typeof Product>
-
-  @column.dateTime({ autoCreate: true })
-  declare createdAt: DateTime
-
-  @column.dateTime({ autoCreate: true, autoUpdate: true })
-  declare updatedAt: DateTime
 }

--- a/apps/api/app/models/payment_method.ts
+++ b/apps/api/app/models/payment_method.ts
@@ -1,5 +1,5 @@
 import { DateTime } from 'luxon'
-import { BaseModel, column, belongsTo } from '@adonisjs/lucid/orm'
+import { BaseModel, belongsTo, column } from '@adonisjs/lucid/orm'
 import type { BelongsTo } from '@adonisjs/lucid/types/relations'
 import User from '#models/user'
 
@@ -17,17 +17,26 @@ export default class PaymentMethod extends BaseModel {
   declare stripePaymentMethodId: string
 
   @column()
+  declare brand: string | null
+
+  @column()
   declare lastFour: string
 
   @column()
-  declare isDefault: boolean
+  declare expMonth: number | null
 
-  @belongsTo(() => User)
-  declare user: BelongsTo<typeof User>
+  @column()
+  declare expYear: number | null
+
+  @column()
+  declare isDefault: boolean
 
   @column.dateTime({ autoCreate: true })
   declare createdAt: DateTime
 
   @column.dateTime({ autoCreate: true, autoUpdate: true })
-  declare updatedAt: DateTime
+  declare updatedAt: DateTime | null
+
+  @belongsTo(() => User)
+  declare user: BelongsTo<typeof User>
 }

--- a/apps/api/app/models/payment_method.ts
+++ b/apps/api/app/models/payment_method.ts
@@ -1,0 +1,33 @@
+import { DateTime } from 'luxon'
+import { BaseModel, column, belongsTo } from '@adonisjs/lucid/orm'
+import type { BelongsTo } from '@adonisjs/lucid/types/relations'
+import User from '#models/user'
+
+export default class PaymentMethod extends BaseModel {
+  @column({ isPrimary: true })
+  declare id: number
+
+  @column()
+  declare userId: number
+
+  @column()
+  declare type: string
+
+  @column()
+  declare stripePaymentMethodId: string
+
+  @column()
+  declare lastFour: string
+
+  @column()
+  declare isDefault: boolean
+
+  @belongsTo(() => User)
+  declare user: BelongsTo<typeof User>
+
+  @column.dateTime({ autoCreate: true })
+  declare createdAt: DateTime
+
+  @column.dateTime({ autoCreate: true, autoUpdate: true })
+  declare updatedAt: DateTime
+}

--- a/apps/api/app/models/product.ts
+++ b/apps/api/app/models/product.ts
@@ -1,0 +1,39 @@
+import { DateTime } from 'luxon'
+import { BaseModel, column, belongsTo } from '@adonisjs/lucid/orm'
+import type { BelongsTo } from '@adonisjs/lucid/types/relations'
+import Category from '#models/category'
+
+export default class Product extends BaseModel {
+  @column({ isPrimary: true })
+  declare id: number
+
+  @column()
+  declare name: string
+
+  @column()
+  declare slug: string
+
+  @column()
+  declare description: string | null
+
+  @column()
+  declare price: number
+
+  @column()
+  declare stock: number
+
+  @column()
+  declare categoryId: number
+
+  @column()
+  declare isActive: boolean
+
+  @belongsTo(() => Category)
+  declare category: BelongsTo<typeof Category>
+
+  @column.dateTime({ autoCreate: true })
+  declare createdAt: DateTime
+
+  @column.dateTime({ autoCreate: true, autoUpdate: true })
+  declare updatedAt: DateTime
+}

--- a/apps/api/app/models/product.ts
+++ b/apps/api/app/models/product.ts
@@ -1,5 +1,5 @@
 import { DateTime } from 'luxon'
-import { BaseModel, column, belongsTo } from '@adonisjs/lucid/orm'
+import { BaseModel, belongsTo, column } from '@adonisjs/lucid/orm'
 import type { BelongsTo } from '@adonisjs/lucid/types/relations'
 import Category from '#models/category'
 
@@ -23,17 +23,20 @@ export default class Product extends BaseModel {
   declare stock: number
 
   @column()
-  declare categoryId: number
+  declare categoryId: number | null
 
   @column()
   declare isActive: boolean
 
-  @belongsTo(() => Category)
-  declare category: BelongsTo<typeof Category>
+  @column()
+  declare sortPriority: number
 
   @column.dateTime({ autoCreate: true })
   declare createdAt: DateTime
 
   @column.dateTime({ autoCreate: true, autoUpdate: true })
-  declare updatedAt: DateTime
+  declare updatedAt: DateTime | null
+
+  @belongsTo(() => Category)
+  declare category: BelongsTo<typeof Category>
 }

--- a/apps/api/app/models/user.ts
+++ b/apps/api/app/models/user.ts
@@ -20,6 +20,12 @@ export default class User extends compose(BaseModel, AuthFinder) {
   @column()
   declare email: string
 
+  @column()
+  declare phone: string | null
+
+  @column()
+  declare role: 'customer' | 'admin'
+
   @column({ serializeAs: null })
   declare password: string
 

--- a/apps/api/app/services/mongo_service.ts
+++ b/apps/api/app/services/mongo_service.ts
@@ -1,0 +1,45 @@
+import { MongoClient, GridFSBucket } from 'mongodb'
+import env from '#start/env'
+
+class MongoService {
+  private client: MongoClient | null = null
+  private bucket: GridFSBucket | null = null
+
+  async connect() {
+    if (this.client) {
+      return
+    }
+
+    this.client = new MongoClient(env.get('MONGO_URI'))
+    await this.client.connect()
+
+    const db = this.client.db(env.get('MONGO_DATABASE'))
+    this.bucket = new GridFSBucket(db, { bucketName: 'images' })
+  }
+
+  async disconnect() {
+    if (!this.client) {
+      return
+    }
+
+    await this.client.close()
+    this.client = null
+    this.bucket = null
+  }
+
+  getBucket() {
+    if (!this.bucket) {
+      throw new Error('MongoDB not connected')
+    }
+    return this.bucket
+  }
+
+  getClient() {
+    if (!this.client) {
+      throw new Error('MongoDB not connected')
+    }
+    return this.client
+  }
+}
+
+export default new MongoService()

--- a/apps/api/app/services/mongo_service.ts
+++ b/apps/api/app/services/mongo_service.ts
@@ -1,44 +1,50 @@
-import { MongoClient, GridFSBucket } from 'mongodb'
+import { MongoClient, GridFSBucket, type Db } from 'mongodb'
 import env from '#start/env'
+
+const IMAGES_BUCKET = 'images'
 
 class MongoService {
   private client: MongoClient | null = null
+  private db: Db | null = null
   private bucket: GridFSBucket | null = null
 
   async connect() {
-    if (this.client) {
-      return
-    }
+    if (this.client) return
 
-    this.client = new MongoClient(env.get('MONGO_URI'))
-    await this.client.connect()
+    const client = new MongoClient(env.get('MONGO_URI'))
+    await client.connect()
 
-    const db = this.client.db(env.get('MONGO_DATABASE'))
-    this.bucket = new GridFSBucket(db, { bucketName: 'images' })
+    this.client = client
+    this.db = client.db(env.get('MONGO_DATABASE'))
+    this.bucket = new GridFSBucket(this.db, { bucketName: IMAGES_BUCKET })
   }
 
   async disconnect() {
-    if (!this.client) {
-      return
-    }
+    if (!this.client) return
 
     await this.client.close()
     this.client = null
+    this.db = null
     this.bucket = null
   }
 
-  getBucket() {
-    if (!this.bucket) {
-      throw new Error('MongoDB not connected')
-    }
-    return this.bucket
+  getClient() {
+    return this.requireConnection(this.client, 'client')
   }
 
-  getClient() {
-    if (!this.client) {
-      throw new Error('MongoDB not connected')
+  getDb() {
+    return this.requireConnection(this.db, 'database')
+  }
+
+  getBucket() {
+    return this.requireConnection(this.bucket, 'images bucket')
+  }
+
+  private requireConnection<T>(value: T | null, name: string): T {
+    if (!value) {
+      throw new Error(`MongoDB ${name} is not connected — call connect() first`)
     }
-    return this.client
+    return value
   }
 }
 

--- a/apps/api/database/migrations/1773243473806_create_update_users_table_add_role_and_phones_table.ts
+++ b/apps/api/database/migrations/1773243473806_create_update_users_table_add_role_and_phones_table.ts
@@ -1,0 +1,19 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'users'
+
+  async up() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.string('phone').nullable()
+      table.string('role').notNullable().defaultTo('customer')
+    })
+  }
+
+  async down() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.dropColumn('phone')
+      table.dropColumn('role')
+    })
+  }
+}

--- a/apps/api/database/migrations/1773243476675_create_create_categories_table.ts
+++ b/apps/api/database/migrations/1773243476675_create_create_categories_table.ts
@@ -1,0 +1,22 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'categories'
+
+  async up() {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id').notNullable()
+      table.string('name').notNullable()
+      table.string('slug').notNullable().unique()
+      table.text('description').nullable()
+      table.integer('parent_id').unsigned().nullable().references('id').inTable('categories').onDelete('CASCADE')
+
+      table.timestamp('created_at').notNullable()
+      table.timestamp('updated_at').notNullable()
+    })
+  }
+
+  async down() {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/apps/api/database/migrations/1773243476675_create_create_categories_table.ts
+++ b/apps/api/database/migrations/1773243476675_create_create_categories_table.ts
@@ -9,10 +9,18 @@ export default class extends BaseSchema {
       table.string('name').notNullable()
       table.string('slug').notNullable().unique()
       table.text('description').nullable()
-      table.integer('parent_id').unsigned().nullable().references('id').inTable('categories').onDelete('CASCADE')
+      table
+        .integer('parent_id')
+        .unsigned()
+        .nullable()
+        .references('id')
+        .inTable('categories')
+        .onDelete('SET NULL')
+      table.string('image_path').nullable()
+      table.integer('position').notNullable().defaultTo(0)
 
       table.timestamp('created_at').notNullable()
-      table.timestamp('updated_at').notNullable()
+      table.timestamp('updated_at').nullable()
     })
   }
 

--- a/apps/api/database/migrations/1773243479523_create_create_products_table.ts
+++ b/apps/api/database/migrations/1773243479523_create_create_products_table.ts
@@ -11,11 +11,18 @@ export default class extends BaseSchema {
       table.text('description').nullable()
       table.decimal('price', 10, 2).notNullable()
       table.integer('stock').notNullable().defaultTo(0)
-      table.integer('category_id').unsigned().notNullable().references('id').inTable('categories').onDelete('CASCADE')
+      table
+        .integer('category_id')
+        .unsigned()
+        .nullable()
+        .references('id')
+        .inTable('categories')
+        .onDelete('SET NULL')
       table.boolean('is_active').notNullable().defaultTo(true)
+      table.integer('sort_priority').notNullable().defaultTo(0)
 
       table.timestamp('created_at').notNullable()
-      table.timestamp('updated_at').notNullable()
+      table.timestamp('updated_at').nullable()
     })
   }
 

--- a/apps/api/database/migrations/1773243479523_create_create_products_table.ts
+++ b/apps/api/database/migrations/1773243479523_create_create_products_table.ts
@@ -1,0 +1,25 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'products'
+
+  async up() {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id').notNullable()
+      table.string('name').notNullable()
+      table.string('slug').notNullable().unique()
+      table.text('description').nullable()
+      table.decimal('price', 10, 2).notNullable()
+      table.integer('stock').notNullable().defaultTo(0)
+      table.integer('category_id').unsigned().notNullable().references('id').inTable('categories').onDelete('CASCADE')
+      table.boolean('is_active').notNullable().defaultTo(true)
+
+      table.timestamp('created_at').notNullable()
+      table.timestamp('updated_at').notNullable()
+    })
+  }
+
+  async down() {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/apps/api/database/migrations/1773243482397_create_create_addresses_table.ts
+++ b/apps/api/database/migrations/1773243482397_create_create_addresses_table.ts
@@ -1,0 +1,25 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'addresses'
+
+  async up() {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id').notNullable()
+      table.integer('user_id').unsigned().notNullable().references('id').inTable('users').onDelete('CASCADE')
+      table.string('type').notNullable()
+      table.string('street').notNullable()
+      table.string('city').notNullable()
+      table.string('postal_code').notNullable()
+      table.string('country').notNullable()
+      table.boolean('is_default').notNullable().defaultTo(false)
+
+      table.timestamp('created_at').notNullable()
+      table.timestamp('updated_at').notNullable()
+    })
+  }
+
+  async down() {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/apps/api/database/migrations/1773243482397_create_create_addresses_table.ts
+++ b/apps/api/database/migrations/1773243482397_create_create_addresses_table.ts
@@ -6,16 +6,26 @@ export default class extends BaseSchema {
   async up() {
     this.schema.createTable(this.tableName, (table) => {
       table.increments('id').notNullable()
-      table.integer('user_id').unsigned().notNullable().references('id').inTable('users').onDelete('CASCADE')
+      table
+        .integer('user_id')
+        .unsigned()
+        .notNullable()
+        .references('id')
+        .inTable('users')
+        .onDelete('CASCADE')
       table.string('type').notNullable()
+      table.string('full_name').notNullable()
       table.string('street').notNullable()
+      table.string('line2').nullable()
       table.string('city').notNullable()
-      table.string('postal_code').notNullable()
-      table.string('country').notNullable()
+      table.string('region').nullable()
+      table.string('postal_code', 32).notNullable()
+      table.string('country', 2).notNullable()
+      table.string('phone', 32).nullable()
       table.boolean('is_default').notNullable().defaultTo(false)
 
       table.timestamp('created_at').notNullable()
-      table.timestamp('updated_at').notNullable()
+      table.timestamp('updated_at').nullable()
     })
   }
 

--- a/apps/api/database/migrations/1773243484247_create_create_payment_methods_table.ts
+++ b/apps/api/database/migrations/1773243484247_create_create_payment_methods_table.ts
@@ -6,14 +6,25 @@ export default class extends BaseSchema {
   async up() {
     this.schema.createTable(this.tableName, (table) => {
       table.increments('id').notNullable()
-      table.integer('user_id').unsigned().notNullable().references('id').inTable('users').onDelete('CASCADE')
+      table
+        .integer('user_id')
+        .unsigned()
+        .notNullable()
+        .references('id')
+        .inTable('users')
+        .onDelete('CASCADE')
       table.string('type').notNullable()
       table.string('stripe_payment_method_id').notNullable()
-      table.string('last_four').notNullable()
+      table.string('brand', 32).nullable()
+      table.string('last_four', 4).notNullable()
+      table.smallint('exp_month').nullable()
+      table.smallint('exp_year').nullable()
       table.boolean('is_default').notNullable().defaultTo(false)
 
       table.timestamp('created_at').notNullable()
-      table.timestamp('updated_at').notNullable()
+      table.timestamp('updated_at').nullable()
+
+      table.unique(['stripe_payment_method_id'])
     })
   }
 

--- a/apps/api/database/migrations/1773243485233_create_create_orders_table.ts
+++ b/apps/api/database/migrations/1773243485233_create_create_orders_table.ts
@@ -6,17 +6,44 @@ export default class extends BaseSchema {
   async up() {
     this.schema.createTable(this.tableName, (table) => {
       table.increments('id').notNullable()
-      table.integer('user_id').unsigned().notNullable().references('id').inTable('users').onDelete('CASCADE')
+      table
+        .integer('user_id')
+        .unsigned()
+        .notNullable()
+        .references('id')
+        .inTable('users')
+        .onDelete('RESTRICT')
       table.string('status').notNullable().defaultTo('pending')
       table.decimal('subtotal', 10, 2).notNullable()
-      table.decimal('tax', 10, 2).notNullable()
-      table.decimal('shipping_cost', 10, 2).notNullable()
+      table.decimal('tax', 10, 2).notNullable().defaultTo(0)
+      table.decimal('shipping_cost', 10, 2).notNullable().defaultTo(0)
       table.decimal('total', 10, 2).notNullable()
-      table.integer('shipping_address_id').unsigned().notNullable().references('id').inTable('addresses')
-      table.integer('billing_address_id').unsigned().notNullable().references('id').inTable('addresses')
+      table
+        .integer('shipping_address_id')
+        .unsigned()
+        .nullable()
+        .references('id')
+        .inTable('addresses')
+        .onDelete('SET NULL')
+      table
+        .integer('billing_address_id')
+        .unsigned()
+        .nullable()
+        .references('id')
+        .inTable('addresses')
+        .onDelete('SET NULL')
+      table
+        .integer('payment_method_id')
+        .unsigned()
+        .nullable()
+        .references('id')
+        .inTable('payment_methods')
+        .onDelete('SET NULL')
+      table.string('stripe_payment_intent_id').nullable()
+      table.timestamp('placed_at').nullable()
 
       table.timestamp('created_at').notNullable()
-      table.timestamp('updated_at').notNullable()
+      table.timestamp('updated_at').nullable()
     })
   }
 

--- a/apps/api/database/migrations/1773243485233_create_create_orders_table.ts
+++ b/apps/api/database/migrations/1773243485233_create_create_orders_table.ts
@@ -1,0 +1,26 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'orders'
+
+  async up() {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id').notNullable()
+      table.integer('user_id').unsigned().notNullable().references('id').inTable('users').onDelete('CASCADE')
+      table.string('status').notNullable().defaultTo('pending')
+      table.decimal('subtotal', 10, 2).notNullable()
+      table.decimal('tax', 10, 2).notNullable()
+      table.decimal('shipping_cost', 10, 2).notNullable()
+      table.decimal('total', 10, 2).notNullable()
+      table.integer('shipping_address_id').unsigned().notNullable().references('id').inTable('addresses')
+      table.integer('billing_address_id').unsigned().notNullable().references('id').inTable('addresses')
+
+      table.timestamp('created_at').notNullable()
+      table.timestamp('updated_at').notNullable()
+    })
+  }
+
+  async down() {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/apps/api/database/migrations/1773243488041_create_create_order_items_table.ts
+++ b/apps/api/database/migrations/1773243488041_create_create_order_items_table.ts
@@ -1,0 +1,23 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'order_items'
+
+  async up() {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id').notNullable()
+      table.integer('order_id').unsigned().notNullable().references('id').inTable('orders').onDelete('CASCADE')
+      table.integer('product_id').unsigned().notNullable().references('id').inTable('products').onDelete('RESTRICT')
+      table.integer('quantity').notNullable()
+      table.decimal('unit_price', 10, 2).notNullable()
+      table.decimal('total', 10, 2).notNullable()
+
+      table.timestamp('created_at').notNullable()
+      table.timestamp('updated_at').notNullable()
+    })
+  }
+
+  async down() {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/apps/api/database/migrations/1773243488041_create_create_order_items_table.ts
+++ b/apps/api/database/migrations/1773243488041_create_create_order_items_table.ts
@@ -6,14 +6,27 @@ export default class extends BaseSchema {
   async up() {
     this.schema.createTable(this.tableName, (table) => {
       table.increments('id').notNullable()
-      table.integer('order_id').unsigned().notNullable().references('id').inTable('orders').onDelete('CASCADE')
-      table.integer('product_id').unsigned().notNullable().references('id').inTable('products').onDelete('RESTRICT')
+      table
+        .integer('order_id')
+        .unsigned()
+        .notNullable()
+        .references('id')
+        .inTable('orders')
+        .onDelete('CASCADE')
+      table
+        .integer('product_id')
+        .unsigned()
+        .nullable()
+        .references('id')
+        .inTable('products')
+        .onDelete('SET NULL')
+      table.string('product_name').notNullable()
       table.integer('quantity').notNullable()
       table.decimal('unit_price', 10, 2).notNullable()
       table.decimal('total', 10, 2).notNullable()
 
       table.timestamp('created_at').notNullable()
-      table.timestamp('updated_at').notNullable()
+      table.timestamp('updated_at').nullable()
     })
   }
 

--- a/apps/api/database/migrations/1773243490757_create_create_payment_methods_table.ts
+++ b/apps/api/database/migrations/1773243490757_create_create_payment_methods_table.ts
@@ -1,0 +1,23 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'payment_methods'
+
+  async up() {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id').notNullable()
+      table.integer('user_id').unsigned().notNullable().references('id').inTable('users').onDelete('CASCADE')
+      table.string('type').notNullable()
+      table.string('stripe_payment_method_id').notNullable()
+      table.string('last_four').notNullable()
+      table.boolean('is_default').notNullable().defaultTo(false)
+
+      table.timestamp('created_at').notNullable()
+      table.timestamp('updated_at').notNullable()
+    })
+  }
+
+  async down() {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/apps/api/database/migrations/1773243493247_create_create_invoices_table.ts
+++ b/apps/api/database/migrations/1773243493247_create_create_invoices_table.ts
@@ -6,15 +6,22 @@ export default class extends BaseSchema {
   async up() {
     this.schema.createTable(this.tableName, (table) => {
       table.increments('id').notNullable()
-      table.integer('order_id').unsigned().notNullable().references('id').inTable('orders').onDelete('CASCADE')
+      table
+        .integer('order_id')
+        .unsigned()
+        .notNullable()
+        .references('id')
+        .inTable('orders')
+        .onDelete('RESTRICT')
       table.string('invoice_number').notNullable().unique()
       table.decimal('subtotal', 10, 2).notNullable()
-      table.decimal('tax', 10, 2).notNullable()
+      table.decimal('tax', 10, 2).notNullable().defaultTo(0)
       table.decimal('total', 10, 2).notNullable()
+      table.string('pdf_path').nullable()
       table.timestamp('issued_at').notNullable()
 
       table.timestamp('created_at').notNullable()
-      table.timestamp('updated_at').notNullable()
+      table.timestamp('updated_at').nullable()
     })
   }
 

--- a/apps/api/database/migrations/1773243493247_create_create_invoices_table.ts
+++ b/apps/api/database/migrations/1773243493247_create_create_invoices_table.ts
@@ -1,0 +1,24 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'invoices'
+
+  async up() {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id').notNullable()
+      table.integer('order_id').unsigned().notNullable().references('id').inTable('orders').onDelete('CASCADE')
+      table.string('invoice_number').notNullable().unique()
+      table.decimal('subtotal', 10, 2).notNullable()
+      table.decimal('tax', 10, 2).notNullable()
+      table.decimal('total', 10, 2).notNullable()
+      table.timestamp('issued_at').notNullable()
+
+      table.timestamp('created_at').notNullable()
+      table.timestamp('updated_at').notNullable()
+    })
+  }
+
+  async down() {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/apps/api/database/migrations/1773243495868_create_create_credit_notes_table.ts
+++ b/apps/api/database/migrations/1773243495868_create_create_credit_notes_table.ts
@@ -6,14 +6,21 @@ export default class extends BaseSchema {
   async up() {
     this.schema.createTable(this.tableName, (table) => {
       table.increments('id').notNullable()
-      table.integer('invoice_id').unsigned().notNullable().references('id').inTable('invoices').onDelete('CASCADE')
+      table
+        .integer('invoice_id')
+        .unsigned()
+        .notNullable()
+        .references('id')
+        .inTable('invoices')
+        .onDelete('RESTRICT')
       table.string('credit_note_number').notNullable().unique()
       table.decimal('amount', 10, 2).notNullable()
-      table.text('reason').notNullable()
+      table.string('reason').nullable()
+      table.string('pdf_path').nullable()
       table.timestamp('issued_at').notNullable()
 
       table.timestamp('created_at').notNullable()
-      table.timestamp('updated_at').notNullable()
+      table.timestamp('updated_at').nullable()
     })
   }
 

--- a/apps/api/database/migrations/1773243495868_create_create_credit_notes_table.ts
+++ b/apps/api/database/migrations/1773243495868_create_create_credit_notes_table.ts
@@ -1,0 +1,23 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'credit_notes'
+
+  async up() {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id').notNullable()
+      table.integer('invoice_id').unsigned().notNullable().references('id').inTable('invoices').onDelete('CASCADE')
+      table.string('credit_note_number').notNullable().unique()
+      table.decimal('amount', 10, 2).notNullable()
+      table.text('reason').notNullable()
+      table.timestamp('issued_at').notNullable()
+
+      table.timestamp('created_at').notNullable()
+      table.timestamp('updated_at').notNullable()
+    })
+  }
+
+  async down() {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/apps/api/database/migrations/1773243498419_create_create_contact_messages_table.ts
+++ b/apps/api/database/migrations/1773243498419_create_create_contact_messages_table.ts
@@ -6,14 +6,21 @@ export default class extends BaseSchema {
   async up() {
     this.schema.createTable(this.tableName, (table) => {
       table.increments('id').notNullable()
+      table
+        .integer('user_id')
+        .unsigned()
+        .nullable()
+        .references('id')
+        .inTable('users')
+        .onDelete('SET NULL')
       table.string('name').notNullable()
-      table.string('email').notNullable()
+      table.string('email', 254).notNullable()
       table.string('subject').notNullable()
       table.text('message').notNullable()
       table.boolean('is_read').notNullable().defaultTo(false)
 
       table.timestamp('created_at').notNullable()
-      table.timestamp('updated_at').notNullable()
+      table.timestamp('updated_at').nullable()
     })
   }
 

--- a/apps/api/database/migrations/1773243498419_create_create_contact_messages_table.ts
+++ b/apps/api/database/migrations/1773243498419_create_create_contact_messages_table.ts
@@ -1,0 +1,23 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'contact_messages'
+
+  async up() {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id').notNullable()
+      table.string('name').notNullable()
+      table.string('email').notNullable()
+      table.string('subject').notNullable()
+      table.text('message').notNullable()
+      table.boolean('is_read').notNullable().defaultTo(false)
+
+      table.timestamp('created_at').notNullable()
+      table.timestamp('updated_at').notNullable()
+    })
+  }
+
+  async down() {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -57,6 +57,7 @@
     "@adonisjs/lucid": "^21.6.1",
     "@vinejs/vine": "^3.0.1",
     "luxon": "^3.7.2",
+    "mongodb": "^7.1.0",
     "pg": "^8.18.0",
     "reflect-metadata": "^0.2.2"
   },

--- a/apps/api/start/env.ts
+++ b/apps/api/start/env.ts
@@ -1,14 +1,3 @@
-/*
-|--------------------------------------------------------------------------
-| Environment variables service
-|--------------------------------------------------------------------------
-|
-| The `Env.create` method creates an instance of the Env service. The
-| service validates the environment variables and also cast values
-| to JavaScript data types.
-|
-*/
-
 import { Env } from '@adonisjs/core/env'
 
 export default await Env.create(new URL('../', import.meta.url), {
@@ -18,22 +7,12 @@ export default await Env.create(new URL('../', import.meta.url), {
   HOST: Env.schema.string({ format: 'host' }),
   LOG_LEVEL: Env.schema.enum(['fatal', 'error', 'warn', 'info', 'debug', 'trace', 'silent']),
 
-  /*
-  |----------------------------------------------------------
-  | Variables for configuring database connection
-  |----------------------------------------------------------
-  */
   DB_HOST: Env.schema.string({ format: 'host' }),
   DB_PORT: Env.schema.number(),
   DB_USER: Env.schema.string(),
   DB_PASSWORD: Env.schema.string.optional(),
   DB_DATABASE: Env.schema.string(),
 
-  /*
-  |----------------------------------------------------------
-  | Variables for configuring MongoDB connection
-  |----------------------------------------------------------
-  */
   MONGO_URI: Env.schema.string(),
-  MONGO_DATABASE: Env.schema.string()
+  MONGO_DATABASE: Env.schema.string(),
 })

--- a/apps/api/start/env.ts
+++ b/apps/api/start/env.ts
@@ -27,5 +27,13 @@ export default await Env.create(new URL('../', import.meta.url), {
   DB_PORT: Env.schema.number(),
   DB_USER: Env.schema.string(),
   DB_PASSWORD: Env.schema.string.optional(),
-  DB_DATABASE: Env.schema.string()
+  DB_DATABASE: Env.schema.string(),
+
+  /*
+  |----------------------------------------------------------
+  | Variables for configuring MongoDB connection
+  |----------------------------------------------------------
+  */
+  MONGO_URI: Env.schema.string(),
+  MONGO_DATABASE: Env.schema.string()
 })

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,8 @@ services:
       DB_USER: althea
       DB_PASSWORD: althea_secret
       DB_DATABASE: althea_dev
+      MONGO_URI: mongodb://mongo:27017
+      MONGO_DATABASE: althea_images
       HOST: 0.0.0.0
       PORT: 3333
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,6 +28,9 @@ importers:
       luxon:
         specifier: ^3.7.2
         version: 3.7.2
+      mongodb:
+        specifier: ^7.1.0
+        version: 7.1.0
       pg:
         specifier: ^8.18.0
         version: 8.18.0
@@ -1084,6 +1087,9 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  '@mongodb-js/saslprep@1.4.6':
+    resolution: {integrity: sha512-y+x3H1xBZd38n10NZF/rEBlvDOOMQ6LKUTHqr8R9VkJ+mmQOYtJFxIlkkK8fZrtOiL6VixbOBWMbZGBdal3Z1g==}
+
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
@@ -1289,48 +1295,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-minify/binding-linux-arm64-musl@0.112.0':
     resolution: {integrity: sha512-IRFMZX589lr3rjG0jc8N261/7wqFq2Vl0OMrJWeFls5BF8HiB+fRYuf0Zy2CyRH6NCY2vbdDdp+QCAavQGVsGw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-minify/binding-linux-ppc64-gnu@0.112.0':
     resolution: {integrity: sha512-V/69XqIW9hCUceDpcZh79oDg+F4ptEgIfKRENzYs41LRbSoJ7sNjjcW4zifqyviTvzcnXLgK4uoTyoymmNZBMQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-minify/binding-linux-riscv64-gnu@0.112.0':
     resolution: {integrity: sha512-zghvexySyGXGNW+MutjZN7UGTyOQl56RWMlPe1gb+knBm/+0hf9qjk7Q6ofm2tSte+vQolPfQttifGl0dP9uvQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-minify/binding-linux-riscv64-musl@0.112.0':
     resolution: {integrity: sha512-E4a8VUFDJPb2mPcc7J4NQQPi1ssHKF7/g4r6KD2+SBVERIaEEd3cGNqR7SG3g82/BLGV2UDoQe/WvZCkt5M/bQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-minify/binding-linux-s390x-gnu@0.112.0':
     resolution: {integrity: sha512-2Hx87sK3y6jBV364Mvv0zyxiITIuy26Ixenv6pK7e+4an3HgNdhAj8nk3aLoLTTSvLik5/MaGhcZGEu9tYV1aA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-minify/binding-linux-x64-gnu@0.112.0':
     resolution: {integrity: sha512-2MSCnEPLk9ddSouMhJo78Xy2/JbYC80OYzWdR4yWTGSULsgH3d1VXg73DSwFL8vU7Ad9oK10DioBY2ww7sQTEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-minify/binding-linux-x64-musl@0.112.0':
     resolution: {integrity: sha512-HAPfmQKlkVi97/zRonVE9t/kKUG3ni+mOuU1Euw+3s37KwUuOJjmcwXdclVgXKBlTkCGO0FajPwW5dAJeIXCCw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-minify/binding-openharmony-arm64@0.112.0':
     resolution: {integrity: sha512-bLnMojcPadYzMNpB6IAqMiTOag4etc0zbs8On73JsotO1W5c5/j/ncplpSokpEpNasKRUpHVRXpmq0KRXprNhw==}
@@ -1408,48 +1422,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-arm64-musl@0.112.0':
     resolution: {integrity: sha512-3R0iqjM3xYOZCnwgcxOQXH7hrz64/USDIuLbNTM1kZqQzRqaR4w7SwoWKU934zABo8d0op2oSwOp+CV3hZnM7A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-linux-ppc64-gnu@0.112.0':
     resolution: {integrity: sha512-lAQf8PQxfgy7h0bmcfSVE3hg3qMueshPYULFsCrHM+8KefGZ9W+ZMvRyU33gLrB4w1O3Fz1orR0hmKMCRxXNrQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-gnu@0.112.0':
     resolution: {integrity: sha512-2QlvQBUhHuAE3ezD4X3CAEKMXdfgInggQ5Bj/7gb5NcYP3GyfLTj7c+mMu+BRwfC9B3AXBNyqHWbqEuuUvZyRQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-riscv64-musl@0.112.0':
     resolution: {integrity: sha512-v06iu0osHszgqJ1dLQRb6leWFU1sjG/UQk4MoVBtE6ZPewgfTkby6G9II1SpEAf2onnAuQceVYxQH9iuU3NJqw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-linux-s390x-gnu@0.112.0':
     resolution: {integrity: sha512-+5HhNHtxsdcd7+ljXFnn9FOoCNXJX3UPgIfIE6vdwS1HqdGNH6eAcVobuqGOp54l8pvcxDQA6F4cPswCgLrQfQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-gnu@0.112.0':
     resolution: {integrity: sha512-jKwO7ZLNkjxwg7FoCLw+fJszooL9yXRZsDN0AQ1AQUTWq1l8GH/2e44k68N3fcP19jl8O8jGpqLAZcQTYk6skA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-musl@0.112.0':
     resolution: {integrity: sha512-TYqnuKV/p3eOc+N61E0961nA7DC+gaCeJ3+V2LcjJdTwFMdikqWL6uVk1jlrpUCBrozHDATVUKDZYH7r4FQYjQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-parser/binding-openharmony-arm64@0.112.0':
     resolution: {integrity: sha512-ZhrVmWFifVEFQX4XPwLoVFDHw9tAWH9p9vHsHFH+5uCKdfVR+jje4WxVo6YrokWCboGckoOzHq5KKMOcPZfkRg==}
@@ -1530,48 +1552,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-transform/binding-linux-arm64-musl@0.112.0':
     resolution: {integrity: sha512-Lg6VOuSd3oXv7J0eGywgqh/086h+qQzIBOD+47pYKMTTJcbDe+f3h/RgGoMKJE5HhiwT5sH1aGEJfIfaYUiVSw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-transform/binding-linux-ppc64-gnu@0.112.0':
     resolution: {integrity: sha512-PXzmj82o1moA4IGphYImTRgc2youTi4VRfyFX3CHwLjxPcQ5JtcsgbDt4QUdOzXZ+zC07s5jf2ZzhRapEOlj2w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-transform/binding-linux-riscv64-gnu@0.112.0':
     resolution: {integrity: sha512-vhJsMsVH/6xwa3bt1LGts33FXUkGjaEGDwsRyp4lIfOjSfQVWMtCmWMFNaA0dW9FVWdD2Gt2fSFBSZ+azDxlpg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-transform/binding-linux-riscv64-musl@0.112.0':
     resolution: {integrity: sha512-cXWFb7z+2IjFUEcXtRwluq9oEG5qnyFCjiu3SWrgYNcWwPdHusv3I/7K5/CTbbi4StoZ5txbi7/iSfDHNyWuRw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-transform/binding-linux-s390x-gnu@0.112.0':
     resolution: {integrity: sha512-eEFu4SRqJTJ20/88KRWmp+jpHKAw0Y1DsnSgpEeXyBIIcsOaLIUMU/TfYWUmqRbvbMV9rmOmI3kp5xWYUq6kSQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-transform/binding-linux-x64-gnu@0.112.0':
     resolution: {integrity: sha512-ST1MDT+TlOyZ1c5btrGinRSUW2Jf4Pa+0gdKwsyjDSOC3dxy2ZNkN3mosTf4ywc3J+mxfYKqtjs7zSwHz03ILA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxc-transform/binding-linux-x64-musl@0.112.0':
     resolution: {integrity: sha512-ISQoA3pD4cyTGpf9sXXeerH6pL2L6EIpdy6oAy2ttkswyVFDyQNVOVIGIdLZDgbpmqGljxZnWqt/J/N68pQaig==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxc-transform/binding-openharmony-arm64@0.112.0':
     resolution: {integrity: sha512-UOGVrGIv7yLJovyEXEyUTADuLq98vd/cbMHFLJweRXD+11I8Tn4jASi4WzdsN8C3BVYGRHrXH2NlSBmhz33a4g==}
@@ -1634,36 +1664,42 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.6':
     resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.6':
     resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.6':
     resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.6':
     resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.6':
     resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-wasm@2.5.6':
     resolution: {integrity: sha512-byAiBZ1t3tXQvc8dMD/eoyE7lTXYorhn+6uVW5AC+JGI1KtJC/LvDche5cfUE+qiefH+Ybq0bUCJU0aB1cSHUA==}
@@ -1889,66 +1925,79 @@ packages:
     resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
     resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.59.0':
     resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.59.0':
     resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
     resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
     resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
     resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.0':
     resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
     resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.59.0':
     resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
@@ -2041,24 +2090,28 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.11.24':
     resolution: {integrity: sha512-ypXLIdszRo0re7PNNaXN0+2lD454G8l9LPK/rbfRXnhLWDBPURxzKlLlU/YGd2zP98wPcVooMmegRSNOKfvErw==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.11.24':
     resolution: {integrity: sha512-IM7d+STVZD48zxcgo69L0yYptfhaaE9cMZ+9OoMxirNafhKKXwoZuufol1+alEFKc+Wbwp+aUPe/DeWC/Lh3dg==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.11.24':
     resolution: {integrity: sha512-DZByJaMVzSfjQKKQn3cqSeqwy6lpMaQDQQ4HPlch9FWtDx/dLcpdIhxssqZXcR2rhaQVIaRQsCqwV6orSDGAGw==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.11.24':
     resolution: {integrity: sha512-Q64Ytn23y9aVDKN5iryFi8mRgyHw3/kyjTjT4qFCa8AEb5sGUuSj//AUZ6c0J7hQKMHlg9do5Etvoe61V98/JQ==}
@@ -2134,24 +2187,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.1':
     resolution: {integrity: sha512-WZA0CHRL/SP1TRbA5mp9htsppSEkWuQ4KsSUumYQnyl8ZdT39ntwqmz4IUHGN6p4XdSlYfJwM4rRzZLShHsGAQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.1':
     resolution: {integrity: sha512-qMFzxI2YlBOLW5PhblzuSWlWfwLHaneBE0xHzLrBgNtqN6mWfs+qYbhryGSXQjFYB1Dzf5w+LN5qbUTPhW7Y5g==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.1':
     resolution: {integrity: sha512-5r1X2FKnCMUPlXTWRYpHdPYUY6a1Ar/t7P24OuiEdEOmms5lyqjDRvVY1yy9Rmioh+AunQ0rWiOTPE8F9A3v5g==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.1':
     resolution: {integrity: sha512-MGFB5cVPvshR85MTJkEvqDUnuNoysrsRxd6vnk1Lf2tbiqNlXpHYZqkqOQalydienEWOHHFyyuTSYRsLfxFJ2Q==}
@@ -2512,6 +2569,12 @@ packages:
   '@types/web-bluetooth@0.0.21':
     resolution: {integrity: sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==}
 
+  '@types/webidl-conversions@7.0.3':
+    resolution: {integrity: sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==}
+
+  '@types/whatwg-url@13.0.0':
+    resolution: {integrity: sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q==}
+
   '@typescript-eslint/eslint-plugin@8.56.1':
     resolution: {integrity: sha512-Jz9ZztpB37dNC+HU2HI28Bs9QXpzCz+y/twHOwhyrIRdbuVDxSytJNDl6z/aAKlaRIwC7y8wJdkBv7FxYGgi0A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -2615,41 +2678,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -3062,6 +3133,10 @@ packages:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  bson@7.2.0:
+    resolution: {integrity: sha512-YCEo7KjMlbNlyHhz7zAZNDpIpQbd+wOEHJYezv0nMYTn4x31eIUM2yomNNubclAt63dObUzKHWsBLJ9QcZNSnQ==}
+    engines: {node: '>=20.19.0'}
 
   buffer-crc32@1.0.0:
     resolution: {integrity: sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==}
@@ -4602,24 +4677,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.31.1:
     resolution: {integrity: sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.31.1:
     resolution: {integrity: sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.31.1:
     resolution: {integrity: sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.31.1:
     resolution: {integrity: sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w==}
@@ -4752,6 +4831,9 @@ packages:
     resolution: {integrity: sha512-DeC6b7QBrZsRs3Y02A6A7lQyzFbsQbqgjI6UW0GigGWV+u1s25TycMr0XHZE4cJce7rY/vyw2ctMQqfDkIhUEA==}
     engines: {node: '>=18'}
 
+  memory-pager@1.5.0:
+    resolution: {integrity: sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==}
+
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
 
@@ -4840,6 +4922,37 @@ packages:
 
   mocked-exports@0.1.1:
     resolution: {integrity: sha512-aF7yRQr/Q0O2/4pIXm6PZ5G+jAd7QS4Yu8m+WEeEHGnbo+7mE36CbLSDQiXYV8bVL3NfmdeqPJct0tUlnjVSnA==}
+
+  mongodb-connection-string-url@7.0.1:
+    resolution: {integrity: sha512-h0AZ9A7IDVwwHyMxmdMXKy+9oNlF0zFoahHiX3vQ8e3KFcSP3VmsmfvtRSuLPxmyv2vjIDxqty8smTgie/SNRQ==}
+    engines: {node: '>=20.19.0'}
+
+  mongodb@7.1.0:
+    resolution: {integrity: sha512-kMfnKunbolQYwCIyrkxNJFB4Ypy91pYqua5NargS/f8ODNSJxT03ZU3n1JqL4mCzbSih8tvmMEMLpKTT7x5gCg==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@aws-sdk/credential-providers': ^3.806.0
+      '@mongodb-js/zstd': ^7.0.0
+      gcp-metadata: ^7.0.1
+      kerberos: ^7.0.0
+      mongodb-client-encryption: '>=7.0.0 <7.1.0'
+      snappy: ^7.3.2
+      socks: ^2.8.6
+    peerDependenciesMeta:
+      '@aws-sdk/credential-providers':
+        optional: true
+      '@mongodb-js/zstd':
+        optional: true
+      gcp-metadata:
+        optional: true
+      kerberos:
+        optional: true
+      mongodb-client-encryption:
+        optional: true
+      snappy:
+        optional: true
+      socks:
+        optional: true
 
   motion-dom@12.34.3:
     resolution: {integrity: sha512-sYgFe+pR9aIM7o4fhs2aXtOI+oqlUd33N9Yoxcgo1Fv7M20sRkHtCmzE/VRNIcq7uNJ+qio+Xubt1FXH3pQ+eQ==}
@@ -5888,6 +6001,9 @@ packages:
     resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
     engines: {node: '>= 12'}
 
+  sparse-bitfield@3.0.3:
+    resolution: {integrity: sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==}
+
   spdx-correct@3.2.0:
     resolution: {integrity: sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==}
 
@@ -6137,6 +6253,10 @@ packages:
 
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
 
   ts-api-utils@2.4.0:
     resolution: {integrity: sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==}
@@ -6586,8 +6706,16 @@ packages:
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
   webpack-virtual-modules@0.6.2:
     resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -7718,6 +7846,10 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
+
+  '@mongodb-js/saslprep@1.4.6':
+    dependencies:
+      sparse-bitfield: 3.0.3
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
@@ -9422,6 +9554,12 @@ snapshots:
 
   '@types/web-bluetooth@0.0.21': {}
 
+  '@types/webidl-conversions@7.0.3': {}
+
+  '@types/whatwg-url@13.0.0':
+    dependencies:
+      '@types/webidl-conversions': 7.0.3
+
   '@typescript-eslint/eslint-plugin@8.56.1(@typescript-eslint/parser@8.56.1(eslint@10.0.1(jiti@2.6.1))(typescript@5.9.3))(eslint@10.0.1(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
@@ -10097,6 +10235,8 @@ snapshots:
       electron-to-chromium: 1.5.302
       node-releases: 2.0.27
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
+
+  bson@7.2.0: {}
 
   buffer-crc32@1.0.0: {}
 
@@ -11828,6 +11968,8 @@ snapshots:
     dependencies:
       mimic-function: 5.0.1
 
+  memory-pager@1.5.0: {}
+
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
@@ -11895,6 +12037,17 @@ snapshots:
       ufo: 1.6.3
 
   mocked-exports@0.1.1: {}
+
+  mongodb-connection-string-url@7.0.1:
+    dependencies:
+      '@types/whatwg-url': 13.0.0
+      whatwg-url: 14.2.0
+
+  mongodb@7.1.0:
+    dependencies:
+      '@mongodb-js/saslprep': 1.4.6
+      bson: 7.2.0
+      mongodb-connection-string-url: 7.0.1
 
   motion-dom@12.34.3:
     dependencies:
@@ -13365,6 +13518,10 @@ snapshots:
 
   source-map@0.7.6: {}
 
+  sparse-bitfield@3.0.3:
+    dependencies:
+      memory-pager: 1.5.0
+
   spdx-correct@3.2.0:
     dependencies:
       spdx-expression-parse: 3.0.1
@@ -13610,6 +13767,10 @@ snapshots:
   totalist@3.0.1: {}
 
   tr46@0.0.3: {}
+
+  tr46@5.1.1:
+    dependencies:
+      punycode: 2.3.1
 
   ts-api-utils@2.4.0(typescript@5.8.3):
     dependencies:
@@ -14063,7 +14224,14 @@ snapshots:
 
   webidl-conversions@3.0.1: {}
 
+  webidl-conversions@7.0.0: {}
+
   webpack-virtual-modules@0.6.2: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
 
   whatwg-url@5.0.0:
     dependencies:


### PR DESCRIPTION
This PR introduces comprehensive database schemas for the e-commerce API, supporting both PostgreSQL and MongoDB.

The implementation includes Lucid ORM models and migrations for all core e-commerce entities: users, products, categories, orders, addresses, payment methods, invoices, credit notes, and contact messages. User model has been enhanced with role management and phone number support.

MongoDB has been configured with GridFS for efficient image storage, providing a scalable solution for handling product images and other binary assets. The MongoDB service is integrated with proper connection handling and environment configuration.

All database schemas follow the established conventions and include proper relationships, constraints, and indexes for optimal performance.