### PR TITLE
feat(api): adonisjs auth endpoints (register, login, refresh, logout, me)

### DIFF
--- a/apps/api/app/controllers/auth_controller.ts
+++ b/apps/api/app/controllers/auth_controller.ts
@@ -1,0 +1,69 @@
+import type { HttpContext } from '@adonisjs/core/http'
+import User from '#models/user'
+import { loginValidator, registerValidator } from '#validators/auth'
+
+const TOKEN_EXPIRES_IN = '7 days'
+const TOKEN_NAME = 'storefront_session'
+
+export default class AuthController {
+  async register({ request, response }: HttpContext) {
+    const payload = await request.validateUsing(registerValidator)
+    const user = await User.create(payload)
+    const token = await User.accessTokens.create(user, ['*'], {
+      name: TOKEN_NAME,
+      expiresIn: TOKEN_EXPIRES_IN,
+    })
+
+    return response.created({
+      user,
+      token: serializeToken(token),
+    })
+  }
+
+  async login({ request }: HttpContext) {
+    const { email, password } = await request.validateUsing(loginValidator)
+    const user = await User.verifyCredentials(email, password)
+    const token = await User.accessTokens.create(user, ['*'], {
+      name: TOKEN_NAME,
+      expiresIn: TOKEN_EXPIRES_IN,
+    })
+
+    return {
+      user,
+      token: serializeToken(token),
+    }
+  }
+
+  async refresh({ auth }: HttpContext) {
+    const user = auth.getUserOrFail()
+    const current = user.currentAccessToken
+    await User.accessTokens.delete(user, current.identifier)
+    const token = await User.accessTokens.create(user, ['*'], {
+      name: TOKEN_NAME,
+      expiresIn: TOKEN_EXPIRES_IN,
+    })
+
+    return {
+      user,
+      token: serializeToken(token),
+    }
+  }
+
+  async logout({ auth, response }: HttpContext) {
+    const user = auth.getUserOrFail()
+    await User.accessTokens.delete(user, user.currentAccessToken.identifier)
+    return response.noContent()
+  }
+
+  async me({ auth }: HttpContext) {
+    return { user: auth.getUserOrFail() }
+  }
+}
+
+function serializeToken(token: Awaited<ReturnType<typeof User.accessTokens.create>>) {
+  return {
+    type: 'bearer' as const,
+    value: token.value!.release(),
+    expiresAt: token.expiresAt,
+  }
+}

--- a/apps/api/app/validators/auth.ts
+++ b/apps/api/app/validators/auth.ts
@@ -1,0 +1,21 @@
+import vine from '@vinejs/vine'
+
+export const registerValidator = vine.compile(
+  vine.object({
+    fullName: vine.string().trim().minLength(2).maxLength(120).optional(),
+    email: vine
+      .string()
+      .trim()
+      .email()
+      .normalizeEmail()
+      .unique({ table: 'users', column: 'email' }),
+    password: vine.string().minLength(8).maxLength(128),
+  })
+)
+
+export const loginValidator = vine.compile(
+  vine.object({
+    email: vine.string().trim().email().normalizeEmail(),
+    password: vine.string(),
+  })
+)

--- a/apps/api/start/routes.ts
+++ b/apps/api/start/routes.ts
@@ -8,9 +8,23 @@
 */
 
 import router from '@adonisjs/core/services/router'
+import { middleware } from './kernel.js'
 
-router.get('/', async () => {
-  return {
-    hello: 'world',
-  }
-})
+const AuthController = () => import('#controllers/auth_controller')
+
+router.get('/', async () => ({ hello: 'world' }))
+
+router
+  .group(() => {
+    router.post('register', [AuthController, 'register'])
+    router.post('login', [AuthController, 'login'])
+
+    router
+      .group(() => {
+        router.post('refresh', [AuthController, 'refresh'])
+        router.post('logout', [AuthController, 'logout'])
+        router.get('me', [AuthController, 'me'])
+      })
+      .use(middleware.auth())
+  })
+  .prefix('/auth')


### PR DESCRIPTION
Implements the AdonisJS access-token auth flow described in the brief: a register endpoint that hashes the password and issues a token, a login endpoint that verifies credentials and issues a token, a refresh endpoint that rotates the current access token, a logout endpoint that revokes it, and a me endpoint that returns the authenticated user. Validation is handled by VineJS using Lucid's auto-augmented unique rule for email uniqueness. Closes #3.