### PR TITLE
feat(storefront): shared layout with header, footer and mobile menu

### DIFF
--- a/apps/storefront/app/app.vue
+++ b/apps/storefront/app/app.vue
@@ -1,6 +1,5 @@
 <template>
-  <div>
-    <NuxtRouteAnnouncer />
-    <NuxtWelcome />
-  </div>
+  <NuxtLayout>
+    <NuxtPage />
+  </NuxtLayout>
 </template>

--- a/apps/storefront/app/components/AppFooter.vue
+++ b/apps/storefront/app/components/AppFooter.vue
@@ -1,0 +1,49 @@
+<script setup lang="ts">
+const legalLinks = [
+  { label: 'CGU', to: '/cgu' },
+  { label: 'Mentions légales', to: '/mentions-legales' },
+  { label: 'Contact', to: '/contact' },
+]
+
+const socialLinks = [
+  { label: 'LinkedIn', href: 'https://www.linkedin.com/' },
+  { label: 'Facebook', href: 'https://www.facebook.com/' },
+  { label: 'Twitter', href: 'https://twitter.com/' },
+]
+</script>
+
+<template>
+  <footer class="hidden border-t border-neutral-100 bg-brand-text text-neutral-50 md:block">
+    <div
+      class="mx-auto flex w-full max-w-[1440px] flex-col gap-6 px-10 py-10 md:flex-row md:items-center md:justify-between"
+    >
+      <p class="font-display text-sm tracking-wide">
+        © {{ new Date().getFullYear() }} Althea Systems
+      </p>
+
+      <nav aria-label="Liens légaux" class="flex flex-wrap items-center gap-6 text-sm">
+        <NuxtLink
+          v-for="link in legalLinks"
+          :key="link.to"
+          :to="link.to"
+          class="transition-colors hover:text-brand-50"
+        >
+          {{ link.label }}
+        </NuxtLink>
+      </nav>
+
+      <ul class="flex items-center gap-4 text-sm">
+        <li v-for="link in socialLinks" :key="link.href">
+          <a
+            :href="link.href"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="transition-colors hover:text-brand-50"
+          >
+            {{ link.label }}
+          </a>
+        </li>
+      </ul>
+    </div>
+  </footer>
+</template>

--- a/apps/storefront/app/components/AppHeader.vue
+++ b/apps/storefront/app/components/AppHeader.vue
@@ -1,0 +1,109 @@
+<script setup lang="ts">
+const { itemCount, isEmpty } = useCart()
+const { isAuthenticated } = useAuth()
+
+const emit = defineEmits<{ (e: 'open-menu'): void }>()
+</script>
+
+<template>
+  <header class="sticky top-0 z-40 bg-white">
+    <div
+      class="mx-auto flex h-20 w-full max-w-[1440px] items-center justify-between gap-6 px-4 md:h-[76px] md:px-10"
+    >
+      <AppLogo class="shrink-0" />
+
+      <div class="hidden flex-1 md:block">
+        <AppSearchBar />
+      </div>
+
+      <div class="flex shrink-0 items-center gap-4 md:gap-6">
+        <NuxtLink
+          to="/cart"
+          class="relative text-neutral-700 transition-colors hover:text-brand-500"
+          aria-label="Panier"
+        >
+          <svg
+            viewBox="0 0 24 24"
+            class="h-6 w-6"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.8"
+            aria-hidden="true"
+          >
+            <path
+              d="M3 4h2.4l2.6 11h11l2-8H7"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+            <circle cx="10" cy="20" r="1.4" fill="currentColor" />
+            <circle cx="18" cy="20" r="1.4" fill="currentColor" />
+          </svg>
+          <span
+            v-if="!isEmpty"
+            class="bg-brand-500 absolute -top-1 -right-2 inline-flex h-4 min-w-4 items-center justify-center rounded-full px-1 text-[10px] leading-none font-semibold text-white"
+            aria-label="Articles dans le panier"
+          >
+            {{ itemCount }}
+          </span>
+        </NuxtLink>
+
+        <button
+          type="button"
+          class="hidden text-neutral-700 transition-colors hover:text-brand-500 md:inline-flex"
+          aria-label="Changer la langue"
+        >
+          <svg
+            viewBox="0 0 24 24"
+            class="h-6 w-6"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.8"
+            aria-hidden="true"
+          >
+            <path d="M3 6h12" stroke-linecap="round" />
+            <path d="M9 4v2" stroke-linecap="round" />
+            <path d="M5 6c0 5 3 8 7 9" stroke-linecap="round" stroke-linejoin="round" />
+            <path d="M14 15c0-3 2-5 4-5s4 2 4 5l-2 5" stroke-linecap="round" stroke-linejoin="round" />
+            <path d="M16 17h6" stroke-linecap="round" />
+          </svg>
+        </button>
+
+        <NuxtLink
+          :to="isAuthenticated ? '/account' : '/login'"
+          class="hidden h-9 w-9 items-center justify-center rounded-full bg-brand-500 text-white transition-colors hover:bg-brand-700 md:inline-flex"
+          :aria-label="isAuthenticated ? 'Mon compte' : 'Se connecter'"
+        >
+          <svg viewBox="0 0 24 24" class="h-5 w-5" fill="currentColor" aria-hidden="true">
+            <circle cx="12" cy="9" r="4" />
+            <path d="M4 21c0-4 4-7 8-7s8 3 8 7" />
+          </svg>
+        </NuxtLink>
+
+        <button
+          type="button"
+          class="text-neutral-700 transition-colors hover:text-brand-500"
+          aria-label="Ouvrir le menu"
+          @click="emit('open-menu')"
+        >
+          <svg
+            viewBox="0 0 24 24"
+            class="h-7 w-7"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            aria-hidden="true"
+          >
+            <path d="M4 7h16" />
+            <path d="M4 12h16" />
+            <path d="M4 17h16" />
+          </svg>
+        </button>
+      </div>
+    </div>
+
+    <div class="border-b border-neutral-100 px-4 pb-3 md:hidden">
+      <AppSearchBar />
+    </div>
+  </header>
+</template>

--- a/apps/storefront/app/components/AppLogo.vue
+++ b/apps/storefront/app/components/AppLogo.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+withDefaults(defineProps<{ withWordmark?: boolean }>(), { withWordmark: true })
+</script>
+
+<template>
+  <NuxtLink to="/" class="inline-flex items-center gap-3" aria-label="Althea Systems">
+    <svg
+      viewBox="0 0 64 64"
+      class="h-10 w-10 text-brand-500"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+      <path
+        d="M14 38c-5 0-9-4-9-9s4-9 9-9c1.4-7 7.7-12.5 15.3-12.5 7 0 12.9 4.6 14.8 11h.4c6.8 0 12.5 5.6 12.5 12.5S51.3 43.5 44.5 43.5H14z"
+        fill="currentColor"
+        fill-opacity="0.18"
+      />
+      <path
+        d="M14 38c-5 0-9-4-9-9s4-9 9-9c1.4-7 7.7-12.5 15.3-12.5 7 0 12.9 4.6 14.8 11h.4c6.8 0 12.5 5.6 12.5 12.5S51.3 43.5 44.5 43.5H14z"
+        stroke="currentColor"
+        stroke-width="2"
+      />
+      <rect x="28" y="22" width="8" height="20" rx="1.5" fill="currentColor" />
+      <rect x="22" y="28" width="20" height="8" rx="1.5" fill="currentColor" />
+    </svg>
+    <span
+      v-if="withWordmark"
+      class="font-display text-xl leading-tight font-medium text-neutral-800"
+    >
+      Althea
+      <br />
+      Systems
+    </span>
+  </NuxtLink>
+</template>

--- a/apps/storefront/app/components/AppMobileMenu.vue
+++ b/apps/storefront/app/components/AppMobileMenu.vue
@@ -1,0 +1,186 @@
+<script setup lang="ts">
+const props = defineProps<{ open: boolean }>()
+const emit = defineEmits<{ (e: 'close'): void }>()
+
+const { isAuthenticated, logout } = useAuth()
+
+const primaryLinks = [
+  { label: 'Accueil', to: '/' },
+  { label: 'Catégories', to: '/categories' },
+  { label: 'Recherche', to: '/search' },
+  { label: 'Contact', to: '/contact' },
+]
+
+const guestLinks = [
+  { label: 'Se connecter', to: '/login' },
+  { label: 'Créer un compte', to: '/register' },
+]
+
+const accountLinks = [
+  { label: 'Mon compte', to: '/account' },
+  { label: 'Mes commandes', to: '/account/orders' },
+]
+
+const legalLinks = [
+  { label: 'CGU', to: '/cgu' },
+  { label: 'Mentions légales', to: '/mentions-legales' },
+  { label: 'Contact', to: '/contact' },
+]
+
+const socialLinks = [
+  { label: 'LinkedIn', href: 'https://www.linkedin.com/' },
+  { label: 'Facebook', href: 'https://www.facebook.com/' },
+  { label: 'Twitter', href: 'https://twitter.com/' },
+]
+
+function close() {
+  emit('close')
+}
+
+function onLogout() {
+  logout()
+  close()
+}
+
+watch(
+  () => props.open,
+  (isOpen) => {
+    if (import.meta.client) {
+      document.documentElement.style.overflow = isOpen ? 'hidden' : ''
+    }
+  }
+)
+</script>
+
+<template>
+  <Teleport to="body">
+    <Transition
+      enter-active-class="transition-opacity duration-200"
+      leave-active-class="transition-opacity duration-200"
+      enter-from-class="opacity-0"
+      leave-to-class="opacity-0"
+    >
+      <div v-if="open" class="fixed inset-0 z-50 bg-neutral-900/50" @click="close" />
+    </Transition>
+
+    <Transition
+      enter-active-class="transition-transform duration-300"
+      leave-active-class="transition-transform duration-300"
+      enter-from-class="translate-x-full"
+      leave-to-class="translate-x-full"
+    >
+      <aside
+        v-if="open"
+        class="fixed inset-y-0 right-0 z-50 flex w-full max-w-[584px] flex-col overflow-y-auto bg-white px-8 py-12 md:px-[52px] md:py-[62px]"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Menu de navigation"
+      >
+        <button
+          type="button"
+          class="self-end text-neutral-700 transition-colors hover:text-brand-500"
+          aria-label="Fermer le menu"
+          @click="close"
+        >
+          <svg
+            viewBox="0 0 24 24"
+            class="h-7 w-7"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            aria-hidden="true"
+          >
+            <path d="M6 6l12 12" />
+            <path d="M18 6 6 18" />
+          </svg>
+        </button>
+
+        <nav
+          aria-label="Navigation principale"
+          class="mt-8 flex flex-col gap-7 font-display text-2xl font-medium tracking-wide text-neutral-900 md:text-[32px]"
+        >
+          <NuxtLink
+            v-for="link in primaryLinks"
+            :key="link.to"
+            :to="link.to"
+            class="transition-colors hover:text-brand-500"
+            @click="close"
+          >
+            {{ link.label }}
+          </NuxtLink>
+        </nav>
+
+        <hr class="my-8 border-neutral-100" />
+
+        <nav
+          v-if="isAuthenticated"
+          aria-label="Compte"
+          class="flex flex-col gap-4 font-sans text-base text-neutral-700"
+        >
+          <NuxtLink
+            v-for="link in accountLinks"
+            :key="link.to"
+            :to="link.to"
+            class="transition-colors hover:text-brand-500"
+            @click="close"
+          >
+            {{ link.label }}
+          </NuxtLink>
+          <button
+            type="button"
+            class="text-left transition-colors hover:text-brand-500"
+            @click="onLogout"
+          >
+            Se déconnecter
+          </button>
+        </nav>
+
+        <nav
+          v-else
+          aria-label="Compte"
+          class="flex flex-col gap-4 font-sans text-base text-neutral-700"
+        >
+          <NuxtLink
+            v-for="link in guestLinks"
+            :key="link.to"
+            :to="link.to"
+            class="transition-colors hover:text-brand-500"
+            @click="close"
+          >
+            {{ link.label }}
+          </NuxtLink>
+        </nav>
+
+        <hr class="my-8 border-neutral-100 md:hidden" />
+
+        <div class="md:hidden">
+          <nav aria-label="Liens légaux" class="flex flex-col gap-3 text-sm text-neutral-600">
+            <NuxtLink
+              v-for="link in legalLinks"
+              :key="link.to"
+              :to="link.to"
+              class="transition-colors hover:text-brand-500"
+              @click="close"
+            >
+              {{ link.label }}
+            </NuxtLink>
+          </nav>
+
+          <ul class="mt-4 flex flex-wrap gap-4 text-sm text-neutral-600">
+            <li v-for="link in socialLinks" :key="link.href">
+              <a
+                :href="link.href"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="transition-colors hover:text-brand-500"
+              >
+                {{ link.label }}
+              </a>
+            </li>
+          </ul>
+        </div>
+      </aside>
+    </Transition>
+  </Teleport>
+</template>

--- a/apps/storefront/app/components/AppSearchBar.vue
+++ b/apps/storefront/app/components/AppSearchBar.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+const router = useRouter()
+const query = ref('')
+
+function onSubmit() {
+  const trimmed = query.value.trim()
+  if (!trimmed) return
+  router.push({ path: '/search', query: { q: trimmed } })
+}
+</script>
+
+<template>
+  <form
+    class="flex w-full items-center justify-between gap-3 rounded-lg border-2 border-neutral-600 bg-neutral-50 px-6 py-4"
+    role="search"
+    @submit.prevent="onSubmit"
+  >
+    <input
+      v-model="query"
+      type="search"
+      name="q"
+      placeholder="Rechercher un produit, une catégorie"
+      class="w-full bg-transparent text-base text-neutral-800 placeholder:text-neutral-600 focus:outline-none"
+      aria-label="Rechercher un produit ou une catégorie"
+    />
+    <button
+      type="submit"
+      class="text-neutral-600 transition-colors hover:text-brand-500"
+      aria-label="Lancer la recherche"
+    >
+      <svg
+        viewBox="0 0 24 24"
+        class="h-6 w-6"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        aria-hidden="true"
+      >
+        <circle cx="11" cy="11" r="7" />
+        <path d="m20 20-3.5-3.5" stroke-linecap="round" />
+      </svg>
+    </button>
+  </form>
+</template>

--- a/apps/storefront/app/composables/useAuth.ts
+++ b/apps/storefront/app/composables/useAuth.ts
@@ -1,0 +1,26 @@
+export interface AuthUser {
+  id: number
+  email: string
+  fullName: string | null
+}
+
+const user = ref<AuthUser | null>(null)
+
+export function useAuth() {
+  const isAuthenticated = computed(() => user.value !== null)
+
+  function setUser(next: AuthUser | null) {
+    user.value = next
+  }
+
+  function logout() {
+    user.value = null
+  }
+
+  return {
+    user,
+    isAuthenticated,
+    setUser,
+    logout,
+  }
+}

--- a/apps/storefront/app/composables/useCart.ts
+++ b/apps/storefront/app/composables/useCart.ts
@@ -1,0 +1,15 @@
+const itemCount = ref(0)
+
+export function useCart() {
+  const isEmpty = computed(() => itemCount.value === 0)
+
+  function setCount(next: number) {
+    itemCount.value = next
+  }
+
+  return {
+    itemCount,
+    isEmpty,
+    setCount,
+  }
+}

--- a/apps/storefront/app/layouts/default.vue
+++ b/apps/storefront/app/layouts/default.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+const menuOpen = ref(false)
+</script>
+
+<template>
+  <div class="flex min-h-screen flex-col bg-white text-neutral-800">
+    <AppHeader @open-menu="menuOpen = true" />
+    <main class="flex-1">
+      <slot />
+    </main>
+    <AppFooter />
+    <AppMobileMenu :open="menuOpen" @close="menuOpen = false" />
+  </div>
+</template>

--- a/apps/storefront/app/pages/index.vue
+++ b/apps/storefront/app/pages/index.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+useHead({ title: 'Althea Systems' })
+</script>
+
+<template>
+  <section class="mx-auto w-full max-w-[1440px] px-4 py-16 md:px-10">
+    <h1 class="font-display text-h1 font-medium text-brand-text">
+      Althea Systems
+    </h1>
+    <p class="mt-4 max-w-2xl text-body-lg text-neutral-700">
+      Plateforme e-commerce de matériel médical de pointe pour les cabinets professionnels.
+    </p>
+  </section>
+</template>

--- a/apps/storefront/assets/css/main.css
+++ b/apps/storefront/assets/css/main.css
@@ -1,1 +1,47 @@
 @import "tailwindcss";
+
+@theme {
+  --color-brand-50: #d4f4f7;
+  --color-brand-300: #33bfc9;
+  --color-brand-500: #00a8b5;
+  --color-brand-700: #0073a1;
+  --color-brand-text: #001f21;
+
+  --color-neutral-white: #f8fafb;
+  --color-neutral-50: #f0f4f6;
+  --color-neutral-100: #e3e9ed;
+  --color-neutral-200: #c9d3da;
+  --color-neutral-300: #a9b7c1;
+  --color-neutral-400: #7e909d;
+  --color-neutral-500: #5f7282;
+  --color-neutral-600: #465a6b;
+  --color-neutral-700: #334555;
+  --color-neutral-800: #1e3040;
+  --color-neutral-900: #152029;
+  --color-neutral-black: #0b1217;
+
+  --color-success: #10b981;
+  --color-danger: #ef4444;
+  --color-warning: #f59e0b;
+  --color-info: #00a8b5;
+
+  --font-sans: "Inter", ui-sans-serif, system-ui, sans-serif;
+  --font-display: "Poppins", ui-sans-serif, system-ui, sans-serif;
+
+  --text-h1: 2rem;
+  --text-h1--line-height: 2.5rem;
+  --text-h2: 1.5rem;
+  --text-h2--line-height: 2rem;
+  --text-h3: 1.25rem;
+  --text-h3--line-height: 1.75rem;
+  --text-h4: 1.125rem;
+  --text-h4--line-height: 1.5rem;
+  --text-body-lg: 1.125rem;
+  --text-body-lg--line-height: 1.75rem;
+  --text-body-sm: 0.875rem;
+  --text-body-sm--line-height: 1.25rem;
+  --text-caption: 0.75rem;
+  --text-caption--line-height: 1rem;
+  --text-price: 1.25rem;
+  --text-price--line-height: 1.75rem;
+}

--- a/apps/storefront/nuxt.config.ts
+++ b/apps/storefront/nuxt.config.ts
@@ -3,7 +3,7 @@ import tailwindcss from "@tailwindcss/vite";
 export default defineNuxtConfig({
   compatibilityDate: '2025-07-15',
   devtools: { enabled: true },
-  css: ['./assets/css/main.css'],
+  css: ['~~/assets/css/main.css'],
   vite: {
     plugins: [tailwindcss()],
   },


### PR DESCRIPTION
Builds the shared storefront layout from the Figma design — header with logo, search bar, cart button with badge, language and account icons, plus a burger trigger that opens a slide-over menu containing the primary navigation in Poppins, a guest or connected sub-section depending on auth state, and the legal and social links that desktop keeps in the footer (mobile only). The Tailwind theme is also widened to mirror Figma's full neutral scale, primary text colour and typed text scales. Closes #4.