### PR TITLE
feat(api): products and categories endpoints with search and gridfs images

### DIFF
--- a/apps/api/adonisrc.ts
+++ b/apps/api/adonisrc.ts
@@ -57,7 +57,11 @@ export default defineConfig({
   | List of modules to import before starting the application.
   |
   */
-  preloads: [() => import('#start/routes'), () => import('#start/kernel')],
+  preloads: [
+    () => import('#start/routes'),
+    () => import('#start/kernel'),
+    () => import('#start/mongo'),
+  ],
 
   /*
   |--------------------------------------------------------------------------

--- a/apps/api/app/controllers/categories_controller.ts
+++ b/apps/api/app/controllers/categories_controller.ts
@@ -1,0 +1,38 @@
+import type { HttpContext } from '@adonisjs/core/http'
+import Category from '#models/category'
+import { createCategoryValidator, updateCategoryValidator } from '#validators/category'
+
+export default class CategoriesController {
+  async index() {
+    return Category.query().orderBy('position', 'asc').orderBy('name', 'asc')
+  }
+
+  async show({ params }: HttpContext) {
+    return Category.query()
+      .where('slug', params.slug)
+      .preload('children', (q) => q.orderBy('position', 'asc'))
+      .firstOrFail()
+  }
+
+  async store({ request, response }: HttpContext) {
+    const payload = await request.validateUsing(createCategoryValidator)
+    const category = await Category.create(payload)
+    return response.created(category)
+  }
+
+  async update({ params, request }: HttpContext) {
+    const category = await Category.findOrFail(params.id)
+    const payload = await request.validateUsing(updateCategoryValidator, {
+      meta: { categoryId: category.id },
+    })
+    category.merge(payload)
+    await category.save()
+    return category
+  }
+
+  async destroy({ params, response }: HttpContext) {
+    const category = await Category.findOrFail(params.id)
+    await category.delete()
+    return response.noContent()
+  }
+}

--- a/apps/api/app/controllers/product_images_controller.ts
+++ b/apps/api/app/controllers/product_images_controller.ts
@@ -1,0 +1,111 @@
+import type { HttpContext } from '@adonisjs/core/http'
+import { ObjectId } from 'mongodb'
+import { Readable } from 'node:stream'
+import Product from '#models/product'
+import mongoService from '#services/mongo_service'
+
+const ALLOWED_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp', 'image/avif']
+const MAX_IMAGE_BYTES = 5 * 1024 * 1024
+
+export default class ProductImagesController {
+  async index({ params }: HttpContext) {
+    const product = await Product.findByOrFail('slug', params.slug)
+    const files = await mongoService
+      .getBucket()
+      .find({ 'metadata.productId': product.id })
+      .sort({ 'metadata.position': 1, uploadDate: 1 })
+      .toArray()
+
+    return files.map(serializeFile)
+  }
+
+  async show({ params, response }: HttpContext) {
+    const id = parseObjectId(params.id)
+    if (!id) return response.notFound()
+
+    const bucket = mongoService.getBucket()
+    const [file] = await bucket.find({ _id: id }).limit(1).toArray()
+    if (!file) return response.notFound()
+
+    const contentType = (file.metadata?.contentType as string) ?? 'application/octet-stream'
+    response.header('Content-Type', contentType)
+    response.header('Cache-Control', 'public, max-age=31536000, immutable')
+    return response.stream(bucket.openDownloadStream(id))
+  }
+
+  async store({ params, request, response }: HttpContext) {
+    const product = await Product.findByOrFail('slug', params.slug)
+    const file = request.file('image', {
+      size: `${MAX_IMAGE_BYTES}b`,
+      extnames: ['jpg', 'jpeg', 'png', 'webp', 'avif'],
+    })
+
+    if (!file || !file.tmpPath) {
+      return response.unprocessableEntity({ message: 'image is required' })
+    }
+    const contentType = `${file.type}/${file.subtype}`
+    if (!file.type || !ALLOWED_MIME_TYPES.includes(contentType)) {
+      return response.unprocessableEntity({ message: 'unsupported image type' })
+    }
+
+    const fs = await import('node:fs')
+    const stream = fs.createReadStream(file.tmpPath)
+    const metadata = {
+      productId: product.id,
+      contentType,
+      position: Number(request.input('position', 0)),
+      alt: request.input('alt', null),
+    }
+    const uploadStream = mongoService.getBucket().openUploadStream(file.clientName, { metadata })
+
+    await pipe(stream, uploadStream)
+    return response.created(
+      serializeFile({
+        _id: uploadStream.id,
+        filename: file.clientName,
+        length: file.size ?? 0,
+        uploadDate: new Date(),
+        metadata,
+      })
+    )
+  }
+
+  async destroy({ params, response }: HttpContext) {
+    const id = parseObjectId(params.id)
+    if (!id) return response.notFound()
+
+    await mongoService.getBucket().delete(id)
+    return response.noContent()
+  }
+}
+
+function parseObjectId(value: string): ObjectId | null {
+  if (!ObjectId.isValid(value)) return null
+  return new ObjectId(value)
+}
+
+function serializeFile(file: {
+  _id: ObjectId | unknown
+  filename: string
+  length: number
+  uploadDate: Date
+  metadata?: Record<string, unknown> | null
+}) {
+  return {
+    id: String(file._id),
+    filename: file.filename,
+    contentType: (file.metadata?.contentType as string | undefined) ?? null,
+    size: file.length,
+    uploadedAt: file.uploadDate,
+    metadata: file.metadata ?? null,
+  }
+}
+
+function pipe(source: Readable, destination: NodeJS.WritableStream): Promise<void> {
+  return new Promise((resolve, reject) => {
+    source.on('error', reject)
+    destination.on('error', reject)
+    destination.on('finish', resolve)
+    source.pipe(destination)
+  })
+}

--- a/apps/api/app/controllers/products_controller.ts
+++ b/apps/api/app/controllers/products_controller.ts
@@ -1,0 +1,58 @@
+import type { HttpContext } from '@adonisjs/core/http'
+import Product from '#models/product'
+import {
+  createProductValidator,
+  listProductsValidator,
+  updateProductValidator,
+} from '#validators/product'
+import { listProducts } from '#services/product_search'
+
+const SIMILAR_PRODUCT_LIMIT = 6
+
+export default class ProductsController {
+  async index({ request }: HttpContext) {
+    const query = await listProductsValidator.validate(request.qs())
+    return listProducts(query)
+  }
+
+  async show({ params }: HttpContext) {
+    return Product.query().where('slug', params.slug).preload('category').firstOrFail()
+  }
+
+  async similar({ params }: HttpContext) {
+    const product = await Product.query().where('slug', params.slug).firstOrFail()
+    if (!product.categoryId) return []
+
+    return Product.query()
+      .where('isActive', true)
+      .where('categoryId', product.categoryId)
+      .whereNot('id', product.id)
+      .orderByRaw('CASE WHEN stock > 0 THEN 0 ELSE 1 END asc')
+      .orderBy('sortPriority', 'desc')
+      .orderByRaw('RANDOM()')
+      .limit(SIMILAR_PRODUCT_LIMIT)
+      .preload('category')
+  }
+
+  async store({ request, response }: HttpContext) {
+    const payload = await request.validateUsing(createProductValidator)
+    const product = await Product.create(payload)
+    return response.created(product)
+  }
+
+  async update({ params, request }: HttpContext) {
+    const product = await Product.findOrFail(params.id)
+    const payload = await request.validateUsing(updateProductValidator, {
+      meta: { productId: product.id },
+    })
+    product.merge(payload)
+    await product.save()
+    return product
+  }
+
+  async destroy({ params, response }: HttpContext) {
+    const product = await Product.findOrFail(params.id)
+    await product.delete()
+    return response.noContent()
+  }
+}

--- a/apps/api/app/middleware/admin_middleware.ts
+++ b/apps/api/app/middleware/admin_middleware.ts
@@ -1,0 +1,15 @@
+import type { HttpContext } from '@adonisjs/core/http'
+import type { NextFn } from '@adonisjs/core/types/http'
+import { errors } from '@adonisjs/auth'
+
+export default class AdminMiddleware {
+  async handle(ctx: HttpContext, next: NextFn) {
+    const user = ctx.auth.user
+    if (!user || user.role !== 'admin') {
+      throw new errors.E_UNAUTHORIZED_ACCESS('Admin access required', {
+        guardDriverName: 'access_tokens',
+      })
+    }
+    return next()
+  }
+}

--- a/apps/api/app/services/product_search.ts
+++ b/apps/api/app/services/product_search.ts
@@ -1,0 +1,106 @@
+import Product from '#models/product'
+import type { ModelQueryBuilderContract } from '@adonisjs/lucid/types/model'
+
+export type SortKey = 'priority' | 'price' | 'date' | 'stock' | 'relevance'
+export type SortOrder = 'asc' | 'desc'
+
+export interface ProductListQuery {
+  q?: string
+  categoryId?: number
+  minPrice?: number
+  maxPrice?: number
+  inStockOnly?: boolean
+  sort?: SortKey
+  order?: SortOrder
+  page?: number
+  perPage?: number
+}
+
+const DEFAULT_PAGE = 1
+const DEFAULT_PER_PAGE = 24
+const RELEVANCE_RANK_SQL = `
+  CASE
+    WHEN LOWER(name) = LOWER(?) THEN 0
+    WHEN LOWER(name) LIKE LOWER(?) || '%' THEN 1
+    WHEN LOWER(name) LIKE '%' || LOWER(?) || '%' THEN 2
+    WHEN LOWER(COALESCE(description, '')) LIKE '%' || LOWER(?) || '%' THEN 3
+    ELSE 4
+  END
+`
+
+export async function listProducts(query: ProductListQuery) {
+  const builder = Product.query().preload('category')
+
+  applyFilters(builder, query)
+  applySort(builder, query)
+
+  const page = query.page ?? DEFAULT_PAGE
+  const perPage = query.perPage ?? DEFAULT_PER_PAGE
+  return builder.paginate(page, perPage)
+}
+
+function applyFilters(
+  builder: ModelQueryBuilderContract<typeof Product>,
+  query: ProductListQuery
+) {
+  builder.where('isActive', true)
+
+  if (query.q) applyFuzzyTextFilter(builder, query.q)
+  if (query.categoryId) builder.where('categoryId', query.categoryId)
+  if (query.minPrice !== undefined) builder.where('price', '>=', query.minPrice)
+  if (query.maxPrice !== undefined) builder.where('price', '<=', query.maxPrice)
+  if (query.inStockOnly) builder.where('stock', '>', 0)
+}
+
+function applyFuzzyTextFilter(
+  builder: ModelQueryBuilderContract<typeof Product>,
+  needle: string
+) {
+  const pattern = `%${needle}%`
+  builder.where((sub) => {
+    sub.whereILike('name', pattern).orWhereILike('description', pattern)
+  })
+}
+
+function applySort(
+  builder: ModelQueryBuilderContract<typeof Product>,
+  query: ProductListQuery
+) {
+  const order = query.order ?? defaultOrderFor(query.sort)
+
+  if (query.q && (!query.sort || query.sort === 'relevance')) {
+    builder
+      .select('*')
+      .select(builder.client.raw(`${RELEVANCE_RANK_SQL} as relevance_rank`, [
+        query.q,
+        query.q,
+        query.q,
+        query.q,
+      ]))
+      .orderBy('relevance_rank', 'asc')
+      .orderBy('stock', 'desc')
+      .orderBy('sortPriority', 'desc')
+    return
+  }
+
+  switch (query.sort) {
+    case 'price':
+      builder.orderBy('price', order).orderBy('stock', 'desc')
+      return
+    case 'date':
+      builder.orderBy('createdAt', order)
+      return
+    case 'stock':
+      builder.orderBy('stock', order)
+      return
+    case 'priority':
+    default:
+      builder.orderByRaw('CASE WHEN stock > 0 THEN 0 ELSE 1 END asc')
+      builder.orderBy('sortPriority', 'desc').orderBy('createdAt', 'desc')
+  }
+}
+
+function defaultOrderFor(sort: SortKey | undefined): SortOrder {
+  if (sort === 'price' || sort === 'stock') return 'asc'
+  return 'desc'
+}

--- a/apps/api/app/validators/category.ts
+++ b/apps/api/app/validators/category.ts
@@ -1,0 +1,40 @@
+import vine from '@vinejs/vine'
+
+const slug = vine
+  .string()
+  .trim()
+  .minLength(2)
+  .maxLength(160)
+  .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/)
+
+export const createCategoryValidator = vine.compile(
+  vine.object({
+    name: vine.string().trim().minLength(2).maxLength(120),
+    slug: slug.clone().unique({ table: 'categories', column: 'slug' }),
+    description: vine.string().trim().maxLength(2000).optional(),
+    parentId: vine.number().positive().optional(),
+    imagePath: vine.string().trim().maxLength(255).optional(),
+    position: vine.number().withoutDecimals().min(0).optional(),
+  })
+)
+
+export const updateCategoryValidator = vine.withMetaData<{ categoryId: number }>().compile(
+  vine.object({
+    name: vine.string().trim().minLength(2).maxLength(120).optional(),
+    slug: slug
+      .clone()
+      .unique(async (db, value, field) => {
+        const row = await db
+          .from('categories')
+          .where('slug', value)
+          .whereNot('id', field.meta.categoryId)
+          .first()
+        return !row
+      })
+      .optional(),
+    description: vine.string().trim().maxLength(2000).nullable().optional(),
+    parentId: vine.number().positive().nullable().optional(),
+    imagePath: vine.string().trim().maxLength(255).nullable().optional(),
+    position: vine.number().withoutDecimals().min(0).optional(),
+  })
+)

--- a/apps/api/app/validators/product.ts
+++ b/apps/api/app/validators/product.ts
@@ -1,0 +1,58 @@
+import vine from '@vinejs/vine'
+
+const slug = vine
+  .string()
+  .trim()
+  .minLength(2)
+  .maxLength(160)
+  .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/)
+
+export const createProductValidator = vine.compile(
+  vine.object({
+    name: vine.string().trim().minLength(2).maxLength(255),
+    slug: slug.clone().unique({ table: 'products', column: 'slug' }),
+    description: vine.string().trim().maxLength(8000).optional(),
+    price: vine.number().positive(),
+    stock: vine.number().withoutDecimals().min(0).optional(),
+    categoryId: vine.number().positive().optional(),
+    isActive: vine.boolean().optional(),
+    sortPriority: vine.number().withoutDecimals().min(0).optional(),
+  })
+)
+
+export const updateProductValidator = vine.withMetaData<{ productId: number }>().compile(
+  vine.object({
+    name: vine.string().trim().minLength(2).maxLength(255).optional(),
+    slug: slug
+      .clone()
+      .unique(async (db, value, field) => {
+        const row = await db
+          .from('products')
+          .where('slug', value)
+          .whereNot('id', field.meta.productId)
+          .first()
+        return !row
+      })
+      .optional(),
+    description: vine.string().trim().maxLength(8000).nullable().optional(),
+    price: vine.number().positive().optional(),
+    stock: vine.number().withoutDecimals().min(0).optional(),
+    categoryId: vine.number().positive().nullable().optional(),
+    isActive: vine.boolean().optional(),
+    sortPriority: vine.number().withoutDecimals().min(0).optional(),
+  })
+)
+
+export const listProductsValidator = vine.compile(
+  vine.object({
+    q: vine.string().trim().minLength(1).maxLength(120).optional(),
+    categoryId: vine.number().positive().optional(),
+    minPrice: vine.number().min(0).optional(),
+    maxPrice: vine.number().min(0).optional(),
+    inStockOnly: vine.boolean().optional(),
+    sort: vine.enum(['priority', 'price', 'date', 'stock', 'relevance'] as const).optional(),
+    order: vine.enum(['asc', 'desc'] as const).optional(),
+    page: vine.number().withoutDecimals().min(1).optional(),
+    perPage: vine.number().withoutDecimals().min(1).max(100).optional(),
+  })
+)

--- a/apps/api/start/kernel.ts
+++ b/apps/api/start/kernel.ts
@@ -39,5 +39,6 @@ router.use([() => import('@adonisjs/core/bodyparser_middleware'), () => import('
  * the routes or the routes group.
  */
 export const middleware = router.named({
-  auth: () => import('#middleware/auth_middleware')
+  auth: () => import('#middleware/auth_middleware'),
+  admin: () => import('#middleware/admin_middleware'),
 })

--- a/apps/api/start/mongo.ts
+++ b/apps/api/start/mongo.ts
@@ -1,0 +1,8 @@
+import app from '@adonisjs/core/services/app'
+import mongoService from '#services/mongo_service'
+
+await mongoService.connect()
+
+app.terminating(async () => {
+  await mongoService.disconnect()
+})

--- a/apps/api/start/routes.ts
+++ b/apps/api/start/routes.ts
@@ -1,16 +1,10 @@
-/*
-|--------------------------------------------------------------------------
-| Routes file
-|--------------------------------------------------------------------------
-|
-| The routes file is used for defining the HTTP routes.
-|
-*/
-
 import router from '@adonisjs/core/services/router'
 import { middleware } from './kernel.js'
 
 const AuthController = () => import('#controllers/auth_controller')
+const ProductsController = () => import('#controllers/products_controller')
+const CategoriesController = () => import('#controllers/categories_controller')
+const ProductImagesController = () => import('#controllers/product_images_controller')
 
 router.get('/', async () => ({ hello: 'world' }))
 
@@ -28,3 +22,41 @@ router
       .use(middleware.auth())
   })
   .prefix('/auth')
+
+router
+  .group(() => {
+    router.get('/', [CategoriesController, 'index'])
+    router.get(':slug', [CategoriesController, 'show'])
+  })
+  .prefix('/categories')
+
+router
+  .group(() => {
+    router.post('/', [CategoriesController, 'store'])
+    router.patch(':id', [CategoriesController, 'update'])
+    router.delete(':id', [CategoriesController, 'destroy'])
+  })
+  .prefix('/admin/categories')
+  .use([middleware.auth(), middleware.admin()])
+
+router
+  .group(() => {
+    router.get('/', [ProductsController, 'index'])
+    router.get(':slug', [ProductsController, 'show'])
+    router.get(':slug/similar', [ProductsController, 'similar'])
+    router.get(':slug/images', [ProductImagesController, 'index'])
+  })
+  .prefix('/products')
+
+router.get('/images/:id', [ProductImagesController, 'show'])
+
+router
+  .group(() => {
+    router.post('/', [ProductsController, 'store'])
+    router.patch(':id', [ProductsController, 'update'])
+    router.delete(':id', [ProductsController, 'destroy'])
+    router.post(':slug/images', [ProductImagesController, 'store'])
+    router.delete('images/:id', [ProductImagesController, 'destroy'])
+  })
+  .prefix('/admin/products')
+  .use([middleware.auth(), middleware.admin()])


### PR DESCRIPTION
Adds the products and categories REST endpoints described in the brief: public listing with filters (category, price range, in-stock-only), text search with relevance ranking (exact name > starts-with > contains > description match) when no explicit sort is given, sorting by priority/price/date/stock with sensible defaults, pagination, and a similar-products endpoint that picks six random in-stock siblings from the same category. Categories expose a public listing and a single category by slug with its children, and an admin CRUD group guarded by an admin middleware that checks the role on the authenticated user. Product images are uploaded and streamed through MongoDB GridFS via a MongoService that connects on boot and disconnects on terminate. Closes #11.