### PR TITLE
feat(storefront): catalog pages — homepage, categories, product detail, search

### DIFF
--- a/apps/api/app/controllers/site_config_controller.ts
+++ b/apps/api/app/controllers/site_config_controller.ts
@@ -1,0 +1,48 @@
+const HOMEPAGE_CONFIG = {
+  carousel: {
+    slides: [
+      {
+        id: 1,
+        eyebrow: 'Nouveauté',
+        title: 'Stéthoscopes électroniques nouvelle génération',
+        body: 'Une qualité audio inégalée pour des diagnostics précis au cabinet.',
+        ctaLabel: 'Découvrir la collection',
+        ctaUrl: '/categories/stethoscopes',
+        imageUrl: '',
+      },
+      {
+        id: 2,
+        eyebrow: 'Engagement',
+        title: 'Service après-vente sous 48 heures partout en France',
+        body: 'Un cabinet ne peut pas attendre. Nos équipes interviennent rapidement.',
+        ctaLabel: 'En savoir plus',
+        ctaUrl: '/contact',
+        imageUrl: '',
+      },
+      {
+        id: 3,
+        eyebrow: 'Sélection',
+        title: 'Le matériel essentiel pour ouvrir votre cabinet',
+        body: 'Nos experts ont composé une sélection prête à l’emploi.',
+        ctaLabel: 'Voir la sélection',
+        ctaUrl: '/categories/cabinet-medical',
+        imageUrl: '',
+      },
+    ],
+  },
+  intro: {
+    body: 'Althea Systems accompagne les professionnels de santé avec un catalogue de matériel médical de pointe, choisi par des praticiens et soutenu par un service après-vente rapide.',
+    stats: [
+      { id: 'expertise', value: '15', label: 'ans d’expertise' },
+      { id: 'cabinets', value: '2000+', label: 'cabinets équipés' },
+      { id: 'sav', value: '48h', label: 'vitesse de réponse SAV' },
+    ],
+  },
+  featuredProductSlugs: [] as string[],
+}
+
+export default class SiteConfigController {
+  async homepage() {
+    return HOMEPAGE_CONFIG
+  }
+}

--- a/apps/api/start/routes.ts
+++ b/apps/api/start/routes.ts
@@ -5,8 +5,11 @@ const AuthController = () => import('#controllers/auth_controller')
 const ProductsController = () => import('#controllers/products_controller')
 const CategoriesController = () => import('#controllers/categories_controller')
 const ProductImagesController = () => import('#controllers/product_images_controller')
+const SiteConfigController = () => import('#controllers/site_config_controller')
 
 router.get('/', async () => ({ hello: 'world' }))
+
+router.get('/site-config/homepage', [SiteConfigController, 'homepage'])
 
 router
   .group(() => {

--- a/apps/storefront/app/components/AppCategoryGrid.vue
+++ b/apps/storefront/app/components/AppCategoryGrid.vue
@@ -1,0 +1,50 @@
+<script setup lang="ts">
+import type { Category } from '~~/app/types/catalog'
+
+defineProps<{ categories: Category[] }>()
+</script>
+
+<template>
+  <section class="bg-neutral-50 py-12 md:py-16">
+    <div class="mx-auto w-full max-w-[1440px] px-4 md:px-10">
+      <header class="flex items-end justify-between">
+        <h2 class="font-display text-h2 font-medium text-brand-text">Nos catégories</h2>
+        <NuxtLink to="/categories" class="text-sm text-brand-500 hover:text-brand-700">
+          Tout voir
+        </NuxtLink>
+      </header>
+
+      <ul
+        v-if="categories.length"
+        class="mt-8 grid grid-cols-2 gap-4 sm:grid-cols-3 md:gap-6 lg:grid-cols-4"
+      >
+        <li v-for="category in categories" :key="category.id">
+          <NuxtLink
+            :to="`/categories/${category.slug}`"
+            class="group block overflow-hidden rounded-xl border border-neutral-100 bg-white transition-shadow hover:shadow-md"
+          >
+            <div class="bg-brand-50 aspect-[4/3] w-full overflow-hidden">
+              <img
+                v-if="category.imagePath"
+                :src="category.imagePath"
+                :alt="category.name"
+                class="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+              />
+              <div
+                v-else
+                class="text-brand-500 flex h-full w-full items-center justify-center font-display text-sm tracking-widest uppercase"
+              >
+                {{ category.name.charAt(0) }}
+              </div>
+            </div>
+            <div class="p-4">
+              <h3 class="font-display text-base font-medium text-brand-text">{{ category.name }}</h3>
+            </div>
+          </NuxtLink>
+        </li>
+      </ul>
+
+      <p v-else class="mt-8 text-sm text-neutral-500">Catégories à venir.</p>
+    </div>
+  </section>
+</template>

--- a/apps/storefront/app/components/AppFeaturedProducts.vue
+++ b/apps/storefront/app/components/AppFeaturedProducts.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+import type { Product } from '~~/app/types/catalog'
+
+defineProps<{ products: Product[] }>()
+</script>
+
+<template>
+  <section class="bg-white py-12 md:py-16">
+    <div class="mx-auto w-full max-w-[1440px] px-4 md:px-10">
+      <header class="flex items-end justify-between">
+        <h2 class="font-display text-h2 font-medium text-brand-text">
+          Top produits du moment
+        </h2>
+      </header>
+
+      <ul
+        v-if="products.length"
+        class="mt-8 grid grid-cols-2 gap-4 sm:grid-cols-3 md:gap-6 lg:grid-cols-4"
+      >
+        <li v-for="product in products" :key="product.id">
+          <AppProductCard :product="product" />
+        </li>
+      </ul>
+
+      <p v-else class="mt-8 text-sm text-neutral-500">
+        Notre sélection sera disponible prochainement.
+      </p>
+    </div>
+  </section>
+</template>

--- a/apps/storefront/app/components/AppHeroCarousel.vue
+++ b/apps/storefront/app/components/AppHeroCarousel.vue
@@ -1,0 +1,134 @@
+<script setup lang="ts">
+import type { HomepageConfig } from '~~/app/types/catalog'
+
+const props = defineProps<{ slides: HomepageConfig['carousel']['slides'] }>()
+
+const activeIndex = ref(0)
+const slideCount = computed(() => props.slides.length)
+
+let timer: ReturnType<typeof setInterval> | null = null
+
+function start() {
+  stop()
+  if (slideCount.value <= 1) return
+  timer = setInterval(next, 6000)
+}
+
+function stop() {
+  if (timer) clearInterval(timer)
+  timer = null
+}
+
+function goTo(index: number) {
+  activeIndex.value = (index + slideCount.value) % slideCount.value
+  start()
+}
+
+function next() {
+  goTo(activeIndex.value + 1)
+}
+
+function previous() {
+  goTo(activeIndex.value - 1)
+}
+
+onMounted(start)
+onBeforeUnmount(stop)
+</script>
+
+<template>
+  <section
+    v-if="slides.length"
+    class="relative overflow-hidden bg-brand-50"
+    aria-roledescription="carousel"
+    @mouseenter="stop"
+    @mouseleave="start"
+  >
+    <div class="mx-auto flex w-full max-w-[1440px] items-center px-4 py-12 md:px-10 md:py-20">
+      <div class="relative w-full">
+        <transition
+          enter-active-class="transition-opacity duration-500"
+          leave-active-class="transition-opacity duration-500"
+          enter-from-class="opacity-0"
+          leave-to-class="opacity-0"
+          mode="out-in"
+        >
+          <article :key="slides[activeIndex]!.id" class="grid gap-6 md:grid-cols-2 md:items-center">
+            <div>
+              <p
+                class="font-sans text-caption tracking-widest text-brand-500 uppercase"
+              >
+                {{ slides[activeIndex]!.eyebrow }}
+              </p>
+              <h2
+                class="font-display text-h2 mt-3 max-w-xl font-medium text-brand-text md:text-h1"
+              >
+                {{ slides[activeIndex]!.title }}
+              </h2>
+              <p class="mt-4 max-w-xl text-body-lg text-neutral-700">
+                {{ slides[activeIndex]!.body }}
+              </p>
+              <NuxtLink
+                :to="slides[activeIndex]!.ctaUrl"
+                class="bg-brand-500 hover:bg-brand-700 mt-8 inline-flex items-center rounded-md px-5 py-3 text-sm font-medium text-white transition-colors"
+              >
+                {{ slides[activeIndex]!.ctaLabel }}
+              </NuxtLink>
+            </div>
+            <div
+              class="bg-brand-300/20 hidden aspect-[4/3] w-full items-center justify-center rounded-2xl md:flex"
+            >
+              <img
+                v-if="slides[activeIndex]!.imageUrl"
+                :src="slides[activeIndex]!.imageUrl"
+                :alt="slides[activeIndex]!.title"
+                class="h-full w-full rounded-2xl object-cover"
+              />
+              <span v-else class="font-display text-brand-500 text-sm tracking-widest uppercase">
+                Visuel à venir
+              </span>
+            </div>
+          </article>
+        </transition>
+      </div>
+    </div>
+
+    <div class="absolute inset-x-0 bottom-4 flex items-center justify-center gap-3">
+      <button
+        v-for="(slide, index) in slides"
+        :key="slide.id"
+        type="button"
+        class="h-2 rounded-full transition-all"
+        :class="
+          index === activeIndex
+            ? 'w-8 bg-brand-500'
+            : 'w-2 bg-brand-500/30 hover:bg-brand-500/60'
+        "
+        :aria-label="`Aller à la diapositive ${index + 1}`"
+        @click="goTo(index)"
+      />
+    </div>
+
+    <button
+      type="button"
+      class="absolute top-1/2 left-4 hidden -translate-y-1/2 rounded-full bg-white p-2 text-neutral-700 shadow transition-colors hover:text-brand-500 md:block"
+      aria-label="Précédent"
+      @click="previous"
+    >
+      <svg viewBox="0 0 24 24" class="h-5 w-5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+        <path d="m15 6-6 6 6 6" />
+      </svg>
+    </button>
+
+    <button
+      type="button"
+      class="absolute top-1/2 right-4 hidden -translate-y-1/2 rounded-full bg-white p-2 text-neutral-700 shadow transition-colors hover:text-brand-500 md:block"
+      aria-label="Suivant"
+      @click="next"
+    >
+      <svg viewBox="0 0 24 24" class="h-5 w-5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+        <path d="m9 6 6 6-6 6" />
+      </svg>
+    </button>
+  </section>
+</template>

--- a/apps/storefront/app/components/AppIntroSection.vue
+++ b/apps/storefront/app/components/AppIntroSection.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+import type { HomepageConfig } from '~~/app/types/catalog'
+
+defineProps<{ intro: HomepageConfig['intro'] }>()
+</script>
+
+<template>
+  <section class="bg-white py-12 md:py-16">
+    <div class="mx-auto w-full max-w-[1440px] px-4 md:px-10">
+      <p class="text-body-lg max-w-3xl text-neutral-700">{{ intro.body }}</p>
+      <dl class="mt-10 grid grid-cols-1 gap-6 md:grid-cols-3">
+        <div
+          v-for="stat in intro.stats"
+          :key="stat.id"
+          class="rounded-xl border border-neutral-100 p-6"
+        >
+          <dt class="text-caption text-neutral-500 uppercase">{{ stat.label }}</dt>
+          <dd class="font-display text-h1 mt-2 font-medium text-brand-500">{{ stat.value }}</dd>
+        </div>
+      </dl>
+    </div>
+  </section>
+</template>

--- a/apps/storefront/app/components/AppProductCard.vue
+++ b/apps/storefront/app/components/AppProductCard.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+import type { Product } from '~~/app/types/catalog'
+
+const props = defineProps<{ product: Product; layout?: 'grid' | 'list' }>()
+
+const layout = computed(() => props.layout ?? 'grid')
+const inStock = computed(() => props.product.stock > 0)
+const isLowStock = computed(() => props.product.stock > 0 && props.product.stock <= 5)
+const formattedPrice = computed(() =>
+  new Intl.NumberFormat('fr-FR', { style: 'currency', currency: 'EUR' }).format(props.product.price)
+)
+</script>
+
+<template>
+  <NuxtLink
+    :to="`/products/${product.slug}`"
+    class="group block overflow-hidden rounded-xl border border-neutral-100 bg-white transition-shadow hover:shadow-md"
+    :class="layout === 'list' ? 'flex gap-4 p-3' : ''"
+  >
+    <div
+      class="bg-brand-50 overflow-hidden"
+      :class="layout === 'list' ? 'h-24 w-24 shrink-0 rounded-lg' : 'aspect-square w-full'"
+    >
+      <div
+        class="text-brand-500 flex h-full w-full items-center justify-center font-display text-xs tracking-widest uppercase"
+      >
+        {{ product.name.charAt(0) }}
+      </div>
+    </div>
+
+    <div class="flex-1 p-4" :class="layout === 'list' ? 'p-0' : ''">
+      <h3 class="font-display text-base font-medium text-brand-text line-clamp-2">
+        {{ product.name }}
+      </h3>
+      <p class="text-price font-display text-brand-500 mt-2">{{ formattedPrice }}</p>
+
+      <p class="mt-2 text-caption">
+        <span v-if="!inStock" class="rounded-full bg-danger/10 px-2 py-0.5 text-danger">
+          En rupture de stock
+        </span>
+        <span v-else-if="isLowStock" class="rounded-full bg-warning/10 px-2 py-0.5 text-warning">
+          Stock faible
+        </span>
+        <span v-else class="rounded-full bg-success/10 px-2 py-0.5 text-success">En stock</span>
+      </p>
+    </div>
+  </NuxtLink>
+</template>

--- a/apps/storefront/app/components/AppProductGrid.vue
+++ b/apps/storefront/app/components/AppProductGrid.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import type { Product } from '~~/app/types/catalog'
+
+const props = defineProps<{
+  products: Product[]
+  layout?: 'grid' | 'list'
+  emptyMessage?: string
+}>()
+
+const layout = computed(() => props.layout ?? 'grid')
+const emptyMessage = computed(() => props.emptyMessage ?? 'Aucun produit pour le moment.')
+</script>
+
+<template>
+  <div v-if="!products.length" class="rounded-xl border border-neutral-100 p-8 text-center">
+    <p class="text-sm text-neutral-500">{{ emptyMessage }}</p>
+  </div>
+  <ul
+    v-else-if="layout === 'list'"
+    class="flex flex-col gap-3"
+  >
+    <li v-for="product in products" :key="product.id">
+      <AppProductCard :product="product" layout="list" />
+    </li>
+  </ul>
+  <ul
+    v-else
+    class="grid grid-cols-1 gap-4 sm:grid-cols-2 md:gap-6 lg:grid-cols-3 xl:grid-cols-4"
+  >
+    <li v-for="product in products" :key="product.id">
+      <AppProductCard :product="product" />
+    </li>
+  </ul>
+</template>

--- a/apps/storefront/app/components/AppSortMenu.vue
+++ b/apps/storefront/app/components/AppSortMenu.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+export type SortOption = {
+  value: string
+  label: string
+  sort: 'priority' | 'price' | 'date' | 'stock' | 'relevance'
+  order: 'asc' | 'desc'
+}
+
+const props = defineProps<{
+  modelValue: string
+  options: SortOption[]
+}>()
+
+const emit = defineEmits<{ (e: 'update:modelValue', value: string): void }>()
+
+function onChange(event: Event) {
+  emit('update:modelValue', (event.target as HTMLSelectElement).value)
+}
+</script>
+
+<template>
+  <label class="inline-flex items-center gap-2 text-sm text-neutral-700">
+    <span class="sr-only md:not-sr-only">Trier par</span>
+    <select
+      :value="props.modelValue"
+      class="rounded-md border border-neutral-200 bg-white px-3 py-2 text-sm text-neutral-800 focus:border-brand-500 focus:outline-none"
+      @change="onChange"
+    >
+      <option v-for="option in props.options" :key="option.value" :value="option.value">
+        {{ option.label }}
+      </option>
+    </select>
+  </label>
+</template>

--- a/apps/storefront/app/composables/useApi.ts
+++ b/apps/storefront/app/composables/useApi.ts
@@ -1,0 +1,4 @@
+export function useApi() {
+  const config = useRuntimeConfig()
+  return $fetch.create({ baseURL: config.public.apiBase })
+}

--- a/apps/storefront/app/composables/useCatalog.ts
+++ b/apps/storefront/app/composables/useCatalog.ts
@@ -1,0 +1,84 @@
+import type {
+  Category,
+  HomepageConfig,
+  PaginatedProducts,
+  Product,
+  ProductImage,
+} from '~~/app/types/catalog'
+
+export interface ProductListParams {
+  q?: string
+  categoryId?: number
+  minPrice?: number
+  maxPrice?: number
+  inStockOnly?: boolean
+  sort?: 'priority' | 'price' | 'date' | 'stock' | 'relevance'
+  order?: 'asc' | 'desc'
+  page?: number
+  perPage?: number
+}
+
+export function useHomepageConfig() {
+  const api = useApi()
+  return useAsyncData('homepage-config', () => api<HomepageConfig>('/site-config/homepage'))
+}
+
+export function useCategories() {
+  const api = useApi()
+  return useAsyncData('categories', () => api<Category[]>('/categories'))
+}
+
+export function useCategory(slug: MaybeRefOrGetter<string>) {
+  const api = useApi()
+  const slugRef = computed(() => toValue(slug))
+  return useAsyncData(
+    () => `category:${slugRef.value}`,
+    () => api<Category>(`/categories/${slugRef.value}`),
+    { watch: [slugRef] }
+  )
+}
+
+export function useProducts(params: MaybeRefOrGetter<ProductListParams> = () => ({})) {
+  const api = useApi()
+  const paramsRef = computed(() => toValue(params))
+  return useAsyncData(
+    () => `products:${JSON.stringify(paramsRef.value)}`,
+    () => api<PaginatedProducts>('/products', { query: paramsRef.value }),
+    { watch: [paramsRef] }
+  )
+}
+
+export function useProduct(slug: MaybeRefOrGetter<string>) {
+  const api = useApi()
+  const slugRef = computed(() => toValue(slug))
+  return useAsyncData(
+    () => `product:${slugRef.value}`,
+    () => api<Product>(`/products/${slugRef.value}`),
+    { watch: [slugRef] }
+  )
+}
+
+export function useSimilarProducts(slug: MaybeRefOrGetter<string>) {
+  const api = useApi()
+  const slugRef = computed(() => toValue(slug))
+  return useAsyncData(
+    () => `similar:${slugRef.value}`,
+    () => api<Product[]>(`/products/${slugRef.value}/similar`),
+    { watch: [slugRef] }
+  )
+}
+
+export function useProductImages(slug: MaybeRefOrGetter<string>) {
+  const api = useApi()
+  const slugRef = computed(() => toValue(slug))
+  return useAsyncData(
+    () => `images:${slugRef.value}`,
+    () => api<ProductImage[]>(`/products/${slugRef.value}/images`),
+    { watch: [slugRef] }
+  )
+}
+
+export function productImageUrl(id: string) {
+  const config = useRuntimeConfig()
+  return `${config.public.apiBase}/images/${id}`
+}

--- a/apps/storefront/app/composables/useMediaQuery.ts
+++ b/apps/storefront/app/composables/useMediaQuery.ts
@@ -1,0 +1,15 @@
+export function useMediaQuery(query: string = '(max-width: 767px)') {
+  const matches = ref(false)
+
+  if (import.meta.client) {
+    const media = window.matchMedia(query)
+    matches.value = media.matches
+    const handler = (event: MediaQueryListEvent) => {
+      matches.value = event.matches
+    }
+    media.addEventListener('change', handler)
+    onScopeDispose(() => media.removeEventListener('change', handler))
+  }
+
+  return matches
+}

--- a/apps/storefront/app/pages/categories/[slug].vue
+++ b/apps/storefront/app/pages/categories/[slug].vue
@@ -1,0 +1,81 @@
+<script setup lang="ts">
+import type { SortOption } from '~/components/AppSortMenu.vue'
+
+const route = useRoute()
+const slug = computed(() => String(route.params.slug))
+
+const { data: category } = await useCategory(slug)
+
+if (!category.value) {
+  throw createError({ statusCode: 404, statusMessage: 'Catégorie introuvable' })
+}
+
+useHead(() => ({ title: `${category.value?.name ?? 'Catégorie'} — Althea Systems` }))
+
+const sortOptions: SortOption[] = [
+  { value: 'priority-desc', label: 'Mis en avant', sort: 'priority', order: 'desc' },
+  { value: 'price-asc', label: 'Prix croissant', sort: 'price', order: 'asc' },
+  { value: 'price-desc', label: 'Prix décroissant', sort: 'price', order: 'desc' },
+  { value: 'date-desc', label: 'Nouveautés', sort: 'date', order: 'desc' },
+  { value: 'stock-desc', label: 'Stock disponible', sort: 'stock', order: 'desc' },
+]
+
+const selectedSort = ref('priority-desc')
+const inStockOnly = ref(false)
+
+const productParams = computed(() => {
+  const option = sortOptions.find((o) => o.value === selectedSort.value)!
+  return {
+    categoryId: category.value!.id,
+    sort: option.sort,
+    order: option.order,
+    inStockOnly: inStockOnly.value || undefined,
+    perPage: 24,
+  }
+})
+
+const { data: productsResult } = await useProducts(productParams)
+const products = computed(() => productsResult.value?.data ?? [])
+const isMobile = useMediaQuery()
+</script>
+
+<template>
+  <div>
+    <header class="bg-brand-50">
+      <div class="mx-auto w-full max-w-[1440px] px-4 py-12 md:px-10 md:py-16">
+        <p class="text-caption text-brand-500 uppercase tracking-widest">Catégorie</p>
+        <h1 class="font-display text-h1 mt-3 font-medium text-brand-text">
+          {{ category!.name }}
+        </h1>
+        <p v-if="category!.description" class="mt-4 max-w-2xl text-body-lg text-neutral-700">
+          {{ category!.description }}
+        </p>
+      </div>
+    </header>
+
+    <section class="mx-auto w-full max-w-[1440px] px-4 py-10 md:px-10 md:py-12">
+      <div class="flex flex-wrap items-center justify-between gap-4">
+        <p class="text-sm text-neutral-600">
+          {{ productsResult?.meta?.total ?? 0 }} produit{{
+            (productsResult?.meta?.total ?? 0) > 1 ? 's' : ''
+          }}
+        </p>
+        <div class="flex items-center gap-4">
+          <label class="inline-flex items-center gap-2 text-sm text-neutral-700">
+            <input
+              v-model="inStockOnly"
+              type="checkbox"
+              class="accent-brand-500 h-4 w-4 rounded border-neutral-300"
+            />
+            Uniquement en stock
+          </label>
+          <AppSortMenu v-model="selectedSort" :options="sortOptions" />
+        </div>
+      </div>
+
+      <div class="mt-8">
+        <AppProductGrid :products="products" :layout="isMobile ? 'list' : 'grid'" />
+      </div>
+    </section>
+  </div>
+</template>

--- a/apps/storefront/app/pages/categories/index.vue
+++ b/apps/storefront/app/pages/categories/index.vue
@@ -1,0 +1,50 @@
+<script setup lang="ts">
+useHead({ title: 'Catégories — Althea Systems' })
+
+const { data: categoriesResult } = await useCategories()
+const categories = computed(() => categoriesResult.value ?? [])
+</script>
+
+<template>
+  <section class="mx-auto w-full max-w-[1440px] px-4 py-12 md:px-10 md:py-16">
+    <h1 class="font-display text-h1 font-medium text-brand-text">Toutes nos catégories</h1>
+    <p class="mt-3 max-w-2xl text-body-lg text-neutral-700">
+      Parcourez l’ensemble des familles de produits proposées par Althea Systems.
+    </p>
+
+    <ul
+      v-if="categories.length"
+      class="mt-10 grid grid-cols-2 gap-4 sm:grid-cols-3 md:gap-6 lg:grid-cols-4"
+    >
+      <li v-for="category in categories" :key="category.id">
+        <NuxtLink
+          :to="`/categories/${category.slug}`"
+          class="group block overflow-hidden rounded-xl border border-neutral-100 bg-white transition-shadow hover:shadow-md"
+        >
+          <div class="bg-brand-50 aspect-[4/3] w-full overflow-hidden">
+            <img
+              v-if="category.imagePath"
+              :src="category.imagePath"
+              :alt="category.name"
+              class="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+            />
+            <div
+              v-else
+              class="text-brand-500 flex h-full w-full items-center justify-center font-display text-sm tracking-widest uppercase"
+            >
+              {{ category.name.charAt(0) }}
+            </div>
+          </div>
+          <div class="p-4">
+            <h2 class="font-display text-base font-medium text-brand-text">{{ category.name }}</h2>
+            <p v-if="category.description" class="mt-1 line-clamp-2 text-sm text-neutral-600">
+              {{ category.description }}
+            </p>
+          </div>
+        </NuxtLink>
+      </li>
+    </ul>
+
+    <p v-else class="mt-10 text-sm text-neutral-500">Aucune catégorie pour le moment.</p>
+  </section>
+</template>

--- a/apps/storefront/app/pages/index.vue
+++ b/apps/storefront/app/pages/index.vue
@@ -1,14 +1,19 @@
 <script setup lang="ts">
-useHead({ title: 'Althea Systems' })
+useHead({ title: 'Althea Systems — matériel médical' })
+
+const { data: homepage } = await useHomepageConfig()
+const { data: categoriesResult } = await useCategories()
+const { data: featured } = await useProducts(() => ({ sort: 'priority', perPage: 8 }))
+
+const categories = computed(() => categoriesResult.value ?? [])
+const featuredProducts = computed(() => featured.value?.data ?? [])
 </script>
 
 <template>
-  <section class="mx-auto w-full max-w-[1440px] px-4 py-16 md:px-10">
-    <h1 class="font-display text-h1 font-medium text-brand-text">
-      Althea Systems
-    </h1>
-    <p class="mt-4 max-w-2xl text-body-lg text-neutral-700">
-      Plateforme e-commerce de matériel médical de pointe pour les cabinets professionnels.
-    </p>
-  </section>
+  <div>
+    <AppHeroCarousel v-if="homepage" :slides="homepage.carousel.slides" />
+    <AppIntroSection v-if="homepage" :intro="homepage.intro" />
+    <AppCategoryGrid :categories="categories" />
+    <AppFeaturedProducts :products="featuredProducts" />
+  </div>
 </template>

--- a/apps/storefront/app/pages/products/[slug].vue
+++ b/apps/storefront/app/pages/products/[slug].vue
@@ -1,0 +1,124 @@
+<script setup lang="ts">
+const route = useRoute()
+const slug = computed(() => String(route.params.slug))
+
+const { data: product } = await useProduct(slug)
+
+if (!product.value) {
+  throw createError({ statusCode: 404, statusMessage: 'Produit introuvable' })
+}
+
+useHead(() => ({ title: `${product.value?.name ?? 'Produit'} — Althea Systems` }))
+
+const { data: similar } = await useSimilarProducts(slug)
+const { data: imagesResult } = await useProductImages(slug)
+
+const images = computed(() => imagesResult.value ?? [])
+const similarProducts = computed(() => similar.value ?? [])
+const activeImageIndex = ref(0)
+const inStock = computed(() => (product.value?.stock ?? 0) > 0)
+const formattedPrice = computed(() =>
+  new Intl.NumberFormat('fr-FR', { style: 'currency', currency: 'EUR' }).format(
+    product.value?.price ?? 0
+  )
+)
+</script>
+
+<template>
+  <article class="mx-auto w-full max-w-[1440px] px-4 py-10 md:px-10 md:py-14">
+    <nav class="text-caption mb-6 text-neutral-500">
+      <NuxtLink to="/" class="hover:text-brand-500">Accueil</NuxtLink>
+      <span class="mx-2">/</span>
+      <NuxtLink
+        v-if="product?.category"
+        :to="`/categories/${product.category.slug}`"
+        class="hover:text-brand-500"
+      >
+        {{ product.category.name }}
+      </NuxtLink>
+      <span v-if="product?.category" class="mx-2">/</span>
+      <span class="text-brand-text">{{ product?.name }}</span>
+    </nav>
+
+    <div class="grid gap-10 md:grid-cols-2">
+      <div>
+        <div
+          class="bg-brand-50 flex aspect-square w-full items-center justify-center overflow-hidden rounded-2xl"
+        >
+          <img
+            v-if="images[activeImageIndex]"
+            :src="productImageUrl(images[activeImageIndex]!.id)"
+            :alt="images[activeImageIndex]!.metadata?.alt ?? product?.name"
+            class="h-full w-full object-cover"
+          />
+          <div
+            v-else
+            class="font-display text-brand-500 text-sm tracking-widest uppercase"
+          >
+            Visuel à venir
+          </div>
+        </div>
+        <ul v-if="images.length > 1" class="mt-4 grid grid-cols-5 gap-3">
+          <li v-for="(image, index) in images" :key="image.id">
+            <button
+              type="button"
+              class="aspect-square w-full overflow-hidden rounded-lg border-2 transition-colors"
+              :class="
+                index === activeImageIndex
+                  ? 'border-brand-500'
+                  : 'border-neutral-100 hover:border-brand-300'
+              "
+              :aria-label="`Voir l'image ${index + 1}`"
+              @click="activeImageIndex = index"
+            >
+              <img
+                :src="productImageUrl(image.id)"
+                :alt="image.metadata?.alt ?? `${product?.name} ${index + 1}`"
+                class="h-full w-full object-cover"
+              />
+            </button>
+          </li>
+        </ul>
+      </div>
+
+      <div>
+        <h1 class="font-display text-h1 font-medium text-brand-text">{{ product?.name }}</h1>
+        <p class="text-price font-display text-brand-500 mt-4">{{ formattedPrice }}</p>
+
+        <p class="mt-3">
+          <span
+            v-if="!inStock"
+            class="bg-danger/10 text-danger inline-flex rounded-full px-3 py-1 text-sm"
+          >
+            En rupture de stock
+          </span>
+          <span
+            v-else
+            class="bg-success/10 text-success inline-flex rounded-full px-3 py-1 text-sm"
+          >
+            En stock
+          </span>
+        </p>
+
+        <p v-if="product?.description" class="mt-6 max-w-xl text-body-lg text-neutral-700">
+          {{ product.description }}
+        </p>
+
+        <button
+          type="button"
+          class="bg-brand-500 hover:bg-brand-700 mt-8 inline-flex items-center justify-center rounded-md px-6 py-3 text-sm font-medium text-white transition-colors disabled:cursor-not-allowed disabled:bg-neutral-300"
+          :disabled="!inStock"
+        >
+          {{ inStock ? 'Ajouter au panier' : 'En rupture de stock' }}
+        </button>
+      </div>
+    </div>
+
+    <section v-if="similarProducts.length" class="mt-16">
+      <h2 class="font-display text-h2 font-medium text-brand-text">Produits similaires</h2>
+      <div class="mt-6">
+        <AppProductGrid :products="similarProducts" />
+      </div>
+    </section>
+  </article>
+</template>

--- a/apps/storefront/app/pages/search.vue
+++ b/apps/storefront/app/pages/search.vue
@@ -1,0 +1,182 @@
+<script setup lang="ts">
+import type { SortOption } from '~/components/AppSortMenu.vue'
+
+useHead({ title: 'Recherche — Althea Systems' })
+
+const route = useRoute()
+const router = useRouter()
+
+const sortOptions: SortOption[] = [
+  { value: 'relevance-desc', label: 'Pertinence', sort: 'relevance', order: 'desc' },
+  { value: 'priority-desc', label: 'Mis en avant', sort: 'priority', order: 'desc' },
+  { value: 'price-asc', label: 'Prix croissant', sort: 'price', order: 'asc' },
+  { value: 'price-desc', label: 'Prix décroissant', sort: 'price', order: 'desc' },
+  { value: 'date-desc', label: 'Nouveautés', sort: 'date', order: 'desc' },
+  { value: 'date-asc', label: 'Plus anciens', sort: 'date', order: 'asc' },
+  { value: 'stock-desc', label: 'Stock disponible', sort: 'stock', order: 'desc' },
+  { value: 'stock-asc', label: 'Stock faible', sort: 'stock', order: 'asc' },
+]
+
+const query = ref(String(route.query.q ?? ''))
+const minPrice = ref(route.query.minPrice ? Number(route.query.minPrice) : undefined)
+const maxPrice = ref(route.query.maxPrice ? Number(route.query.maxPrice) : undefined)
+const categoryId = ref<number | undefined>(
+  route.query.categoryId ? Number(route.query.categoryId) : undefined
+)
+const inStockOnly = ref(route.query.inStockOnly === '1')
+const selectedSort = ref(String(route.query.sort ?? 'relevance-desc'))
+
+const { data: categoriesResult } = await useCategories()
+const categories = computed(() => categoriesResult.value ?? [])
+
+const productParams = computed(() => {
+  const option = sortOptions.find((o) => o.value === selectedSort.value) ?? sortOptions[0]!
+  return {
+    q: query.value || undefined,
+    categoryId: categoryId.value,
+    minPrice: minPrice.value,
+    maxPrice: maxPrice.value,
+    inStockOnly: inStockOnly.value || undefined,
+    sort: option.sort,
+    order: option.order,
+    perPage: 24,
+  }
+})
+
+const { data: productsResult, status } = await useProducts(productParams)
+const products = computed(() => productsResult.value?.data ?? [])
+
+watchDebounced(
+  productParams,
+  () => {
+    router.replace({
+      query: {
+        q: query.value || undefined,
+        categoryId: categoryId.value,
+        minPrice: minPrice.value,
+        maxPrice: maxPrice.value,
+        inStockOnly: inStockOnly.value ? '1' : undefined,
+        sort: selectedSort.value,
+      },
+    })
+  },
+  { debounce: 250 }
+)
+
+function watchDebounced<T>(
+  source: ComputedRef<T>,
+  callback: () => void,
+  options: { debounce: number }
+) {
+  let handle: ReturnType<typeof setTimeout> | null = null
+  watch(source, () => {
+    if (handle) clearTimeout(handle)
+    handle = setTimeout(callback, options.debounce)
+  })
+}
+
+function clearFilters() {
+  query.value = ''
+  minPrice.value = undefined
+  maxPrice.value = undefined
+  categoryId.value = undefined
+  inStockOnly.value = false
+  selectedSort.value = 'relevance-desc'
+}
+</script>
+
+<template>
+  <section class="mx-auto w-full max-w-[1440px] px-4 py-10 md:px-10 md:py-14">
+    <header>
+      <h1 class="font-display text-h1 font-medium text-brand-text">Recherche avancée</h1>
+      <p class="mt-3 max-w-2xl text-body-lg text-neutral-700">
+        Affinez votre recherche par texte, catégorie, prix et disponibilité.
+      </p>
+    </header>
+
+    <div class="mt-10 grid gap-10 md:grid-cols-[280px_1fr]">
+      <aside class="space-y-6 rounded-xl border border-neutral-100 bg-white p-6">
+        <div>
+          <label class="text-caption text-neutral-500 uppercase tracking-wide">Mot-clé</label>
+          <input
+            v-model="query"
+            type="search"
+            placeholder="Stéthoscope, otoscope..."
+            class="bg-neutral-50 mt-2 w-full rounded-md border border-neutral-200 px-3 py-2 text-sm focus:border-brand-500 focus:outline-none"
+          />
+        </div>
+
+        <div>
+          <label class="text-caption text-neutral-500 uppercase tracking-wide">Catégorie</label>
+          <select
+            v-model.number="categoryId"
+            class="mt-2 w-full rounded-md border border-neutral-200 bg-white px-3 py-2 text-sm focus:border-brand-500 focus:outline-none"
+          >
+            <option :value="undefined">Toutes les catégories</option>
+            <option v-for="category in categories" :key="category.id" :value="category.id">
+              {{ category.name }}
+            </option>
+          </select>
+        </div>
+
+        <div>
+          <label class="text-caption text-neutral-500 uppercase tracking-wide">Prix</label>
+          <div class="mt-2 grid grid-cols-2 gap-2">
+            <input
+              v-model.number="minPrice"
+              type="number"
+              min="0"
+              placeholder="Min"
+              class="rounded-md border border-neutral-200 bg-white px-3 py-2 text-sm focus:border-brand-500 focus:outline-none"
+            />
+            <input
+              v-model.number="maxPrice"
+              type="number"
+              min="0"
+              placeholder="Max"
+              class="rounded-md border border-neutral-200 bg-white px-3 py-2 text-sm focus:border-brand-500 focus:outline-none"
+            />
+          </div>
+        </div>
+
+        <label class="inline-flex items-center gap-2 text-sm text-neutral-700">
+          <input
+            v-model="inStockOnly"
+            type="checkbox"
+            class="accent-brand-500 h-4 w-4 rounded border-neutral-300"
+          />
+          Uniquement en stock
+        </label>
+
+        <button
+          type="button"
+          class="w-full rounded-md border border-neutral-200 px-3 py-2 text-sm text-neutral-700 transition-colors hover:border-brand-500 hover:text-brand-500"
+          @click="clearFilters"
+        >
+          Réinitialiser
+        </button>
+      </aside>
+
+      <div>
+        <div class="flex flex-wrap items-center justify-between gap-4">
+          <p class="text-sm text-neutral-600">
+            <span v-if="status === 'pending'">Recherche en cours…</span>
+            <span v-else>
+              {{ productsResult?.meta?.total ?? 0 }} résultat{{
+                (productsResult?.meta?.total ?? 0) > 1 ? 's' : ''
+              }}
+            </span>
+          </p>
+          <AppSortMenu v-model="selectedSort" :options="sortOptions" />
+        </div>
+
+        <div class="mt-6">
+          <AppProductGrid
+            :products="products"
+            empty-message="Aucun produit ne correspond à vos critères."
+          />
+        </div>
+      </div>
+    </div>
+  </section>
+</template>

--- a/apps/storefront/app/types/catalog.ts
+++ b/apps/storefront/app/types/catalog.ts
@@ -1,0 +1,61 @@
+export interface Category {
+  id: number
+  name: string
+  slug: string
+  description: string | null
+  parentId: number | null
+  imagePath: string | null
+  position: number
+  children?: Category[]
+}
+
+export interface Product {
+  id: number
+  name: string
+  slug: string
+  description: string | null
+  price: number
+  stock: number
+  categoryId: number | null
+  isActive: boolean
+  sortPriority: number
+  category?: Category | null
+}
+
+export interface ProductImage {
+  id: string
+  filename: string
+  contentType: string | null
+  size: number
+  uploadedAt: string
+  metadata: { productId: number; position?: number; alt?: string | null } | null
+}
+
+export interface PaginatedProducts {
+  data: Product[]
+  meta: {
+    total: number
+    perPage: number
+    currentPage: number
+    lastPage: number
+  }
+}
+
+export interface HomepageConfig {
+  carousel: {
+    slides: Array<{
+      id: number
+      eyebrow: string
+      title: string
+      body: string
+      ctaLabel: string
+      ctaUrl: string
+      imageUrl: string
+    }>
+  }
+  intro: {
+    body: string
+    stats: Array<{ id: string; value: string; label: string }>
+  }
+  featuredProductSlugs: string[]
+}

--- a/apps/storefront/nuxt.config.ts
+++ b/apps/storefront/nuxt.config.ts
@@ -4,6 +4,11 @@ export default defineNuxtConfig({
   compatibilityDate: '2025-07-15',
   devtools: { enabled: true },
   modules: ['@nuxt/fonts'],
+  runtimeConfig: {
+    public: {
+      apiBase: process.env.NUXT_PUBLIC_API_BASE || 'http://localhost:3333',
+    },
+  },
   css: ['~~/assets/css/main.css'],
   fonts: {
     families: [


### PR DESCRIPTION
Builds the M2 storefront catalog on top of the products API. The homepage now renders a hero carousel of three editable slides, an intro section with the practice statistics, the categories grid (driven by the categories endpoint) and a Top produits du moment grid. Adds public pages for the categories index, a single category with sorting and an in-stock-only filter, the product detail page (image carousel via GridFS, formatted price, availability badge, add-to-cart CTA disabled when out of stock, and six similar products from the same category), and an advanced search page with text, category, price range and availability filters plus a sort menu covering relevance, mise en avant, prix, nouveauté and disponibilité. The storefront talks to the API through a useApi composable backed by a runtime config base URL, and a useCatalog file exposes typed useAsyncData wrappers for products, categories and images. Closes #5, #6, #7, #8, #9, #10.