### PR TITLE
fix(api): allow PATCH method in cors config

### DIFF
--- a/apps/api/config/cors.ts
+++ b/apps/api/config/cors.ts
@@ -1,15 +1,9 @@
 import { defineConfig } from '@adonisjs/cors'
 
-/**
- * Configuration options to tweak the CORS policy. The following
- * options are documented on the official documentation website.
- *
- * https://docs.adonisjs.com/guides/security/cors
- */
 const corsConfig = defineConfig({
   enabled: true,
   origin: true,
-  methods: ['GET', 'HEAD', 'POST', 'PUT', 'DELETE'],
+  methods: ['GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE'],
   headers: true,
   exposeHeaders: [],
   credentials: true,


### PR DESCRIPTION
The account, addresses and payment methods update endpoints all use PATCH, but the cors config only listed GET/HEAD/POST/PUT/DELETE so the browser blocked the preflight. Adding PATCH unblocks the storefront.