### PR TITLE
fix(api): address line2 column name

### DIFF
--- a/apps/api/app/models/address.ts
+++ b/apps/api/app/models/address.ts
@@ -21,7 +21,7 @@ export default class Address extends BaseModel {
   @column()
   declare street: string
 
-  @column()
+  @column({ columnName: 'line2' })
   declare line2: string | null
 
   @column()


### PR DESCRIPTION
Lucid converts the line2 model property to a line_2 column because its snake_case helper treats the digit as a word boundary, but the migration created the column as line2 (no underscore). Pinning the column name explicitly so address creation stops failing.