### PR TITLE
feat(storefront): UX polish — toasts, loading bar, modal, redesigned account/cart/checkout

### DIFF
--- a/apps/storefront/app/components/AppAddressForm.vue
+++ b/apps/storefront/app/components/AppAddressForm.vue
@@ -1,0 +1,188 @@
+<script setup lang="ts">
+import type { AddressInput } from '~/composables/useAccount'
+import { COUNTRIES } from '~~/app/data/countries'
+
+const props = defineProps<{
+  modelValue: AddressInput
+  loading?: boolean
+  errorMessage?: string | null
+  submitLabel?: string
+}>()
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: AddressInput): void
+  (e: 'submit'): void
+  (e: 'cancel'): void
+}>()
+
+function set<K extends keyof AddressInput>(key: K, value: AddressInput[K]) {
+  emit('update:modelValue', { ...props.modelValue, [key]: value })
+}
+
+const firstField = ref<HTMLInputElement | null>(null)
+onMounted(() => {
+  firstField.value?.focus()
+})
+</script>
+
+<template>
+  <form class="space-y-5" @submit.prevent="emit('submit')">
+    <div>
+      <span class="text-caption text-neutral-500 uppercase tracking-wide">Type d’adresse</span>
+      <div class="mt-2 grid grid-cols-2 gap-2">
+        <button
+          type="button"
+          class="rounded-md border px-3 py-2 text-sm font-medium transition-colors"
+          :class="
+            modelValue.type === 'shipping'
+              ? 'border-brand-500 bg-brand-50 text-brand-text'
+              : 'border-neutral-200 text-neutral-600 hover:border-brand-300'
+          "
+          @click="set('type', 'shipping')"
+        >
+          Livraison
+        </button>
+        <button
+          type="button"
+          class="rounded-md border px-3 py-2 text-sm font-medium transition-colors"
+          :class="
+            modelValue.type === 'billing'
+              ? 'border-brand-500 bg-brand-50 text-brand-text'
+              : 'border-neutral-200 text-neutral-600 hover:border-brand-300'
+          "
+          @click="set('type', 'billing')"
+        >
+          Facturation
+        </button>
+      </div>
+    </div>
+
+    <label class="block">
+      <span class="text-caption text-neutral-500 uppercase tracking-wide">Nom complet</span>
+      <input
+        ref="firstField"
+        :value="modelValue.fullName"
+        type="text"
+        autocomplete="name"
+        required
+        class="mt-1 w-full rounded-md border border-neutral-200 bg-white px-3 py-2 text-sm focus:border-brand-500 focus:outline-none"
+        @input="set('fullName', ($event.target as HTMLInputElement).value)"
+      />
+    </label>
+
+    <label class="block">
+      <span class="text-caption text-neutral-500 uppercase tracking-wide">Adresse</span>
+      <input
+        :value="modelValue.street"
+        type="text"
+        autocomplete="address-line1"
+        required
+        placeholder="Numéro et rue"
+        class="mt-1 w-full rounded-md border border-neutral-200 bg-white px-3 py-2 text-sm focus:border-brand-500 focus:outline-none"
+        @input="set('street', ($event.target as HTMLInputElement).value)"
+      />
+    </label>
+
+    <label class="block">
+      <span class="text-caption text-neutral-500 uppercase tracking-wide">Complément</span>
+      <input
+        :value="modelValue.line2 ?? ''"
+        type="text"
+        autocomplete="address-line2"
+        placeholder="Bâtiment, étage, code (optionnel)"
+        class="mt-1 w-full rounded-md border border-neutral-200 bg-white px-3 py-2 text-sm focus:border-brand-500 focus:outline-none"
+        @input="set('line2', ($event.target as HTMLInputElement).value)"
+      />
+    </label>
+
+    <div class="grid grid-cols-1 gap-4 md:grid-cols-[140px_1fr]">
+      <label class="block">
+        <span class="text-caption text-neutral-500 uppercase tracking-wide">Code postal</span>
+        <input
+          :value="modelValue.postalCode"
+          type="text"
+          autocomplete="postal-code"
+          required
+          class="mt-1 w-full rounded-md border border-neutral-200 bg-white px-3 py-2 text-sm focus:border-brand-500 focus:outline-none"
+          @input="set('postalCode', ($event.target as HTMLInputElement).value)"
+        />
+      </label>
+      <label class="block">
+        <span class="text-caption text-neutral-500 uppercase tracking-wide">Ville</span>
+        <input
+          :value="modelValue.city"
+          type="text"
+          autocomplete="address-level2"
+          required
+          class="mt-1 w-full rounded-md border border-neutral-200 bg-white px-3 py-2 text-sm focus:border-brand-500 focus:outline-none"
+          @input="set('city', ($event.target as HTMLInputElement).value)"
+        />
+      </label>
+    </div>
+
+    <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+      <label class="block">
+        <span class="text-caption text-neutral-500 uppercase tracking-wide">Région (optionnel)</span>
+        <input
+          :value="modelValue.region ?? ''"
+          type="text"
+          autocomplete="address-level1"
+          class="mt-1 w-full rounded-md border border-neutral-200 bg-white px-3 py-2 text-sm focus:border-brand-500 focus:outline-none"
+          @input="set('region', ($event.target as HTMLInputElement).value)"
+        />
+      </label>
+      <label class="block">
+        <span class="text-caption text-neutral-500 uppercase tracking-wide">Pays</span>
+        <select
+          :value="modelValue.country"
+          required
+          class="mt-1 w-full rounded-md border border-neutral-200 bg-white px-3 py-2 text-sm focus:border-brand-500 focus:outline-none"
+          @change="set('country', ($event.target as HTMLSelectElement).value)"
+        >
+          <option v-for="country in COUNTRIES" :key="country.code" :value="country.code">
+            {{ country.name }}
+          </option>
+        </select>
+      </label>
+    </div>
+
+    <label class="block">
+      <span class="text-caption text-neutral-500 uppercase tracking-wide">Téléphone (optionnel)</span>
+      <input
+        :value="modelValue.phone ?? ''"
+        type="tel"
+        autocomplete="tel"
+        class="mt-1 w-full rounded-md border border-neutral-200 bg-white px-3 py-2 text-sm focus:border-brand-500 focus:outline-none"
+        @input="set('phone', ($event.target as HTMLInputElement).value)"
+      />
+    </label>
+
+    <label class="inline-flex items-center gap-2 text-sm text-neutral-700">
+      <input
+        :checked="modelValue.isDefault ?? false"
+        type="checkbox"
+        class="accent-brand-500 h-4 w-4 rounded border-neutral-300"
+        @change="set('isDefault', ($event.target as HTMLInputElement).checked)"
+      />
+      Adresse par défaut pour ce type
+    </label>
+
+    <AppFormError :message="errorMessage" />
+
+    <div class="flex items-center justify-end gap-2">
+      <button
+        type="button"
+        class="rounded-md border border-neutral-200 px-4 py-2 text-sm text-neutral-700 hover:border-brand-300"
+        @click="emit('cancel')"
+      >
+        Annuler
+      </button>
+      <button
+        type="submit"
+        class="bg-brand-500 hover:bg-brand-700 inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-medium text-white transition-colors disabled:cursor-not-allowed disabled:bg-neutral-300"
+        :disabled="loading"
+      >
+        {{ loading ? 'Enregistrement…' : (submitLabel ?? 'Enregistrer') }}
+      </button>
+    </div>
+  </form>
+</template>

--- a/apps/storefront/app/components/AppCheckoutSteps.vue
+++ b/apps/storefront/app/components/AppCheckoutSteps.vue
@@ -1,0 +1,59 @@
+<script setup lang="ts">
+const props = defineProps<{ current: 1 | 2 | 3 }>()
+
+const steps = [
+  { id: 1, label: 'Identification' },
+  { id: 2, label: 'Adresses' },
+  { id: 3, label: 'Paiement' },
+] as const
+
+function stateOf(step: number) {
+  if (step < props.current) return 'done'
+  if (step === props.current) return 'current'
+  return 'todo'
+}
+</script>
+
+<template>
+  <ol class="mt-8 flex items-center justify-between gap-4">
+    <li v-for="(step, index) in steps" :key="step.id" class="flex flex-1 items-center gap-3">
+      <span
+        class="flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-sm font-semibold transition-colors"
+        :class="{
+          'bg-brand-500 text-white': stateOf(step.id) === 'current',
+          'bg-success text-white': stateOf(step.id) === 'done',
+          'border border-neutral-200 bg-white text-neutral-500': stateOf(step.id) === 'todo',
+        }"
+      >
+        <svg
+          v-if="stateOf(step.id) === 'done'"
+          viewBox="0 0 24 24"
+          class="h-5 w-5"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="3"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <polyline points="5 12 10 17 19 7" />
+        </svg>
+        <span v-else>{{ step.id }}</span>
+      </span>
+      <span
+        class="text-caption font-medium uppercase tracking-wide"
+        :class="{
+          'text-brand-500': stateOf(step.id) === 'current',
+          'text-success': stateOf(step.id) === 'done',
+          'text-neutral-500': stateOf(step.id) === 'todo',
+        }"
+      >
+        {{ step.label }}
+      </span>
+      <span
+        v-if="index < steps.length - 1"
+        class="hidden h-px flex-1 md:block"
+        :class="stateOf(step.id) === 'done' ? 'bg-success' : 'bg-neutral-100'"
+      />
+    </li>
+  </ol>
+</template>

--- a/apps/storefront/app/components/AppLoadingBar.vue
+++ b/apps/storefront/app/components/AppLoadingBar.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+const indicator = useLoadingIndicator()
+</script>
+
+<template>
+  <div
+    v-show="indicator.isLoading.value"
+    class="bg-brand-500 fixed inset-x-0 top-0 z-[70] h-0.5 origin-left transition-transform duration-200"
+    :style="{ transform: `scaleX(${indicator.progress.value / 100})` }"
+  />
+</template>

--- a/apps/storefront/app/components/AppModal.vue
+++ b/apps/storefront/app/components/AppModal.vue
@@ -1,0 +1,59 @@
+<script setup lang="ts">
+const props = defineProps<{ open: boolean; title?: string }>()
+const emit = defineEmits<{ (e: 'close'): void }>()
+
+watch(
+  () => props.open,
+  (isOpen) => {
+    if (import.meta.client) {
+      document.documentElement.style.overflow = isOpen ? 'hidden' : ''
+    }
+  }
+)
+
+onBeforeUnmount(() => {
+  if (import.meta.client) {
+    document.documentElement.style.overflow = ''
+  }
+})
+</script>
+
+<template>
+  <Teleport to="body">
+    <Transition
+      enter-active-class="transition-opacity duration-200"
+      leave-active-class="transition-opacity duration-200"
+      enter-from-class="opacity-0"
+      leave-to-class="opacity-0"
+    >
+      <div
+        v-if="open"
+        class="fixed inset-0 z-50 flex items-end justify-center bg-neutral-900/60 p-0 md:items-center md:p-4"
+        @click.self="emit('close')"
+      >
+        <div
+          class="max-h-[90vh] w-full overflow-y-auto rounded-t-2xl bg-white p-6 shadow-xl md:max-w-lg md:rounded-2xl"
+          role="dialog"
+          aria-modal="true"
+        >
+          <header v-if="title || $slots.header" class="mb-6 flex items-start justify-between gap-4">
+            <h2 v-if="title" class="font-display text-h3 font-medium text-brand-text">{{ title }}</h2>
+            <slot name="header" />
+            <button
+              type="button"
+              class="text-neutral-500 transition-colors hover:text-brand-500"
+              aria-label="Fermer"
+              @click="emit('close')"
+            >
+              <svg viewBox="0 0 24 24" class="h-6 w-6" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+                <path d="M6 6l12 12" />
+                <path d="M18 6 6 18" />
+              </svg>
+            </button>
+          </header>
+          <slot />
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>

--- a/apps/storefront/app/components/AppSkeleton.vue
+++ b/apps/storefront/app/components/AppSkeleton.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+defineProps<{ class?: string }>()
+</script>
+
+<template>
+  <div
+    class="animate-pulse rounded-md bg-neutral-100"
+    :class="$props.class"
+    aria-hidden="true"
+  />
+</template>

--- a/apps/storefront/app/components/AppToastHost.vue
+++ b/apps/storefront/app/components/AppToastHost.vue
@@ -1,0 +1,43 @@
+<script setup lang="ts">
+const { toasts, dismiss } = useToast()
+
+const toneClasses: Record<string, string> = {
+  success: 'border-success/20 bg-success/10 text-success',
+  error: 'border-danger/20 bg-danger/10 text-danger',
+  info: 'border-brand-300/40 bg-brand-50 text-brand-text',
+}
+</script>
+
+<template>
+  <Teleport to="body">
+    <div
+      class="pointer-events-none fixed inset-x-4 top-4 z-[60] flex flex-col items-end gap-2 md:right-6 md:left-auto md:w-[360px]"
+      aria-live="polite"
+    >
+      <TransitionGroup
+        enter-active-class="transition-all duration-200"
+        leave-active-class="transition-all duration-200"
+        enter-from-class="opacity-0 -translate-y-2"
+        leave-to-class="opacity-0 translate-x-4"
+      >
+        <div
+          v-for="toast in toasts"
+          :key="toast.id"
+          class="pointer-events-auto flex w-full items-start gap-3 rounded-lg border bg-white px-4 py-3 text-sm shadow-md"
+          :class="toneClasses[toast.tone]"
+          role="status"
+        >
+          <span class="flex-1">{{ toast.message }}</span>
+          <button
+            type="button"
+            class="text-current opacity-60 transition-opacity hover:opacity-100"
+            aria-label="Fermer"
+            @click="dismiss(toast.id)"
+          >
+            ×
+          </button>
+        </div>
+      </TransitionGroup>
+    </div>
+  </Teleport>
+</template>

--- a/apps/storefront/app/composables/useToast.ts
+++ b/apps/storefront/app/composables/useToast.ts
@@ -1,0 +1,35 @@
+export type ToastTone = 'success' | 'error' | 'info'
+
+export interface Toast {
+  id: number
+  tone: ToastTone
+  message: string
+}
+
+const TOAST_TIMEOUT_MS = 4000
+let nextId = 0
+
+export function useToast() {
+  const toasts = useState<Toast[]>('toasts', () => [])
+
+  function push(tone: ToastTone, message: string) {
+    if (!message) return
+    const id = ++nextId
+    toasts.value = [...toasts.value, { id, tone, message }]
+    if (import.meta.client) {
+      setTimeout(() => dismiss(id), TOAST_TIMEOUT_MS)
+    }
+  }
+
+  function dismiss(id: number) {
+    toasts.value = toasts.value.filter((toast) => toast.id !== id)
+  }
+
+  return {
+    toasts,
+    success: (message: string) => push('success', message),
+    error: (message: string) => push('error', message),
+    info: (message: string) => push('info', message),
+    dismiss,
+  }
+}

--- a/apps/storefront/app/data/countries.ts
+++ b/apps/storefront/app/data/countries.ts
@@ -1,0 +1,32 @@
+export interface Country {
+  code: string
+  name: string
+}
+
+export const COUNTRIES: Country[] = [
+  { code: 'FR', name: 'France' },
+  { code: 'BE', name: 'Belgique' },
+  { code: 'CH', name: 'Suisse' },
+  { code: 'LU', name: 'Luxembourg' },
+  { code: 'MC', name: 'Monaco' },
+  { code: 'DE', name: 'Allemagne' },
+  { code: 'ES', name: 'Espagne' },
+  { code: 'IT', name: 'Italie' },
+  { code: 'PT', name: 'Portugal' },
+  { code: 'NL', name: 'Pays-Bas' },
+  { code: 'GB', name: 'Royaume-Uni' },
+  { code: 'IE', name: 'Irlande' },
+  { code: 'AT', name: 'Autriche' },
+  { code: 'DK', name: 'Danemark' },
+  { code: 'SE', name: 'Suède' },
+  { code: 'NO', name: 'Norvège' },
+  { code: 'FI', name: 'Finlande' },
+  { code: 'PL', name: 'Pologne' },
+  { code: 'CZ', name: 'République tchèque' },
+  { code: 'CA', name: 'Canada' },
+  { code: 'US', name: 'États-Unis' },
+]
+
+export function countryName(code: string): string {
+  return COUNTRIES.find((country) => country.code === code)?.name ?? code
+}

--- a/apps/storefront/app/layouts/default.vue
+++ b/apps/storefront/app/layouts/default.vue
@@ -4,11 +4,13 @@ const menuOpen = ref(false)
 
 <template>
   <div class="flex min-h-screen flex-col bg-white text-neutral-800">
+    <AppLoadingBar />
     <AppHeader @open-menu="menuOpen = true" />
     <main class="flex-1">
       <slot />
     </main>
     <AppFooter />
     <AppMobileMenu :open="menuOpen" @close="menuOpen = false" />
+    <AppToastHost />
   </div>
 </template>

--- a/apps/storefront/app/pages/account/addresses.vue
+++ b/apps/storefront/app/pages/account/addresses.vue
@@ -1,19 +1,22 @@
 <script setup lang="ts">
 import type { Address, AddressInput } from '~/composables/useAccount'
+import { countryName } from '~~/app/data/countries'
 
 definePageMeta({ middleware: 'auth' })
 useHead({ title: 'Adresses — Althea Systems' })
 
 const account = useAccountApi()
+const toast = useToast()
 
 const addresses = ref<Address[]>([])
 const editing = ref<Address | null>(null)
 const showForm = ref(false)
 const errorMessage = ref<string | null>(null)
 const loading = ref(false)
+const initialLoading = ref(true)
 
 const emptyForm: AddressInput = {
-  type: 'billing',
+  type: 'shipping',
   fullName: '',
   street: '',
   line2: '',
@@ -30,11 +33,16 @@ async function refresh() {
   addresses.value = await account.listAddresses()
 }
 
-await refresh()
+try {
+  await refresh()
+} finally {
+  initialLoading.value = false
+}
 
 function openCreate() {
   editing.value = null
   form.value = { ...emptyForm }
+  errorMessage.value = null
   showForm.value = true
 }
 
@@ -52,6 +60,7 @@ function openEdit(address: Address) {
     phone: address.phone ?? '',
     isDefault: address.isDefault,
   }
+  errorMessage.value = null
   showForm.value = true
 }
 
@@ -61,8 +70,10 @@ async function saveAddress() {
   try {
     if (editing.value) {
       await account.updateAddress(editing.value.id, form.value)
+      toast.success('Adresse mise à jour.')
     } else {
       await account.createAddress(form.value)
+      toast.success('Adresse ajoutée.')
     }
     await refresh()
     showForm.value = false
@@ -75,8 +86,13 @@ async function saveAddress() {
 
 async function removeAddress(id: number) {
   if (!confirm('Supprimer cette adresse ?')) return
-  await account.deleteAddress(id)
-  await refresh()
+  try {
+    await account.deleteAddress(id)
+    toast.success('Adresse supprimée.')
+    await refresh()
+  } catch (err) {
+    toast.error(extractFirstError(err) ?? 'Suppression impossible.')
+  }
 }
 </script>
 
@@ -86,8 +102,14 @@ async function removeAddress(id: number) {
       ← Mon compte
     </NuxtLink>
     <header class="mt-2 flex flex-wrap items-end justify-between gap-4">
-      <h1 class="font-display text-h1 font-medium text-brand-text">Carnet d’adresses</h1>
+      <div>
+        <h1 class="font-display text-h1 font-medium text-brand-text">Carnet d’adresses</h1>
+        <p class="mt-2 text-sm text-neutral-600">
+          Gérez vos adresses de livraison et de facturation.
+        </p>
+      </div>
       <button
+        v-if="addresses.length"
         type="button"
         class="bg-brand-500 hover:bg-brand-700 rounded-md px-4 py-2 text-sm font-medium text-white transition-colors"
         @click="openCreate"
@@ -96,16 +118,23 @@ async function removeAddress(id: number) {
       </button>
     </header>
 
-    <ul v-if="addresses.length" class="mt-8 grid gap-4 md:grid-cols-2">
+    <div v-if="initialLoading" class="mt-8 grid gap-4 md:grid-cols-2">
+      <AppSkeleton class="h-40" />
+      <AppSkeleton class="h-40" />
+    </div>
+
+    <ul v-else-if="addresses.length" class="mt-8 grid gap-4 md:grid-cols-2">
       <li
         v-for="address in addresses"
         :key="address.id"
-        class="rounded-xl border border-neutral-100 bg-white p-5"
+        class="flex flex-col rounded-xl border border-neutral-100 bg-white p-5"
       >
         <div class="flex items-start justify-between">
           <div>
             <p class="font-display text-base font-medium text-brand-text">{{ address.fullName }}</p>
-            <p class="text-caption mt-1 text-neutral-500 uppercase">{{ address.type }}</p>
+            <p class="text-caption mt-1 text-neutral-500 uppercase">
+              {{ address.type === 'billing' ? 'Facturation' : 'Livraison' }}
+            </p>
           </div>
           <span
             v-if="address.isDefault"
@@ -114,24 +143,24 @@ async function removeAddress(id: number) {
             Par défaut
           </span>
         </div>
-        <p class="mt-3 text-sm text-neutral-700">
+        <p class="mt-3 flex-1 text-sm text-neutral-700">
           {{ address.street }}<br />
           <span v-if="address.line2">{{ address.line2 }}<br /></span>
           {{ address.postalCode }} {{ address.city }}<br />
-          <span v-if="address.region">{{ address.region }}, </span>{{ address.country }}<br />
-          <span v-if="address.phone">{{ address.phone }}</span>
+          <span v-if="address.region">{{ address.region }}, </span>{{ countryName(address.country) }}<br />
+          <span v-if="address.phone" class="text-neutral-500">{{ address.phone }}</span>
         </p>
         <div class="mt-4 flex gap-2 text-sm">
           <button
             type="button"
-            class="rounded-md border border-neutral-200 px-3 py-1 text-neutral-700 hover:border-brand-500 hover:text-brand-500"
+            class="rounded-md border border-neutral-200 px-3 py-1 text-neutral-700 transition-colors hover:border-brand-500 hover:text-brand-500"
             @click="openEdit(address)"
           >
             Modifier
           </button>
           <button
             type="button"
-            class="rounded-md border border-neutral-200 px-3 py-1 text-neutral-700 hover:border-danger hover:text-danger"
+            class="hover:border-danger hover:text-danger rounded-md border border-neutral-200 px-3 py-1 text-neutral-700 transition-colors"
             @click="removeAddress(address.id)"
           >
             Supprimer
@@ -140,146 +169,49 @@ async function removeAddress(id: number) {
       </li>
     </ul>
 
-    <p v-else class="mt-8 text-sm text-neutral-500">
-      Vous n’avez pas encore d’adresse enregistrée.
-    </p>
-
-    <Teleport to="body">
-      <div
-        v-if="showForm"
-        class="fixed inset-0 z-50 flex items-center justify-center bg-neutral-900/50 p-4"
-        @click.self="showForm = false"
+    <div
+      v-else
+      class="bg-brand-50 mt-8 flex flex-col items-center justify-center rounded-xl border border-dashed border-brand-300 py-16 text-center"
+    >
+      <svg
+        viewBox="0 0 24 24"
+        class="text-brand-500 mb-4 h-10 w-10"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="1.6"
+        stroke-linecap="round"
+        stroke-linejoin="round"
       >
-        <form
-          class="max-h-full w-full max-w-lg overflow-y-auto rounded-xl bg-white p-6"
-          @submit.prevent="saveAddress"
-        >
-          <h2 class="font-display text-h3 font-medium text-brand-text">
-            {{ editing ? 'Modifier l’adresse' : 'Nouvelle adresse' }}
-          </h2>
+        <path d="M12 21s-7-6.5-7-12a7 7 0 1 1 14 0c0 5.5-7 12-7 12z" />
+        <circle cx="12" cy="9" r="2.5" />
+      </svg>
+      <h2 class="font-display text-h3 font-medium text-brand-text">Aucune adresse enregistrée</h2>
+      <p class="mt-2 max-w-sm text-sm text-neutral-600">
+        Ajoutez une adresse de livraison et de facturation pour finaliser vos commandes plus
+        rapidement.
+      </p>
+      <button
+        type="button"
+        class="bg-brand-500 hover:bg-brand-700 mt-6 rounded-md px-5 py-3 text-sm font-medium text-white transition-colors"
+        @click="openCreate"
+      >
+        Ajouter ma première adresse
+      </button>
+    </div>
 
-          <div class="mt-6 space-y-4">
-            <label class="block">
-              <span class="text-caption text-neutral-500 uppercase">Type</span>
-              <select
-                v-model="form.type"
-                class="mt-1 w-full rounded-md border border-neutral-200 bg-white px-3 py-2 text-sm focus:border-brand-500 focus:outline-none"
-              >
-                <option value="billing">Facturation</option>
-                <option value="shipping">Livraison</option>
-              </select>
-            </label>
-
-            <label class="block">
-              <span class="text-caption text-neutral-500 uppercase">Nom complet</span>
-              <input
-                v-model="form.fullName"
-                type="text"
-                required
-                class="mt-1 w-full rounded-md border border-neutral-200 bg-white px-3 py-2 text-sm focus:border-brand-500 focus:outline-none"
-              />
-            </label>
-
-            <label class="block">
-              <span class="text-caption text-neutral-500 uppercase">Adresse</span>
-              <input
-                v-model="form.street"
-                type="text"
-                required
-                class="mt-1 w-full rounded-md border border-neutral-200 bg-white px-3 py-2 text-sm focus:border-brand-500 focus:outline-none"
-              />
-            </label>
-
-            <label class="block">
-              <span class="text-caption text-neutral-500 uppercase">Complément</span>
-              <input
-                v-model="form.line2"
-                type="text"
-                class="mt-1 w-full rounded-md border border-neutral-200 bg-white px-3 py-2 text-sm focus:border-brand-500 focus:outline-none"
-              />
-            </label>
-
-            <div class="grid grid-cols-2 gap-4">
-              <label class="block">
-                <span class="text-caption text-neutral-500 uppercase">Ville</span>
-                <input
-                  v-model="form.city"
-                  type="text"
-                  required
-                  class="mt-1 w-full rounded-md border border-neutral-200 bg-white px-3 py-2 text-sm focus:border-brand-500 focus:outline-none"
-                />
-              </label>
-              <label class="block">
-                <span class="text-caption text-neutral-500 uppercase">Région</span>
-                <input
-                  v-model="form.region"
-                  type="text"
-                  class="mt-1 w-full rounded-md border border-neutral-200 bg-white px-3 py-2 text-sm focus:border-brand-500 focus:outline-none"
-                />
-              </label>
-            </div>
-
-            <div class="grid grid-cols-2 gap-4">
-              <label class="block">
-                <span class="text-caption text-neutral-500 uppercase">Code postal</span>
-                <input
-                  v-model="form.postalCode"
-                  type="text"
-                  required
-                  class="mt-1 w-full rounded-md border border-neutral-200 bg-white px-3 py-2 text-sm focus:border-brand-500 focus:outline-none"
-                />
-              </label>
-              <label class="block">
-                <span class="text-caption text-neutral-500 uppercase">Pays (ISO)</span>
-                <input
-                  v-model="form.country"
-                  type="text"
-                  maxlength="2"
-                  required
-                  class="mt-1 w-full rounded-md border border-neutral-200 bg-white px-3 py-2 text-sm focus:border-brand-500 focus:outline-none uppercase"
-                />
-              </label>
-            </div>
-
-            <label class="block">
-              <span class="text-caption text-neutral-500 uppercase">Téléphone</span>
-              <input
-                v-model="form.phone"
-                type="tel"
-                class="mt-1 w-full rounded-md border border-neutral-200 bg-white px-3 py-2 text-sm focus:border-brand-500 focus:outline-none"
-              />
-            </label>
-
-            <label class="inline-flex items-center gap-2 text-sm text-neutral-700">
-              <input
-                v-model="form.isDefault"
-                type="checkbox"
-                class="accent-brand-500 h-4 w-4 rounded border-neutral-300"
-              />
-              Adresse par défaut pour ce type
-            </label>
-          </div>
-
-          <AppFormError :message="errorMessage" />
-
-          <div class="mt-6 flex justify-end gap-2">
-            <button
-              type="button"
-              class="rounded-md border border-neutral-200 px-4 py-2 text-sm text-neutral-700"
-              @click="showForm = false"
-            >
-              Annuler
-            </button>
-            <button
-              type="submit"
-              class="bg-brand-500 hover:bg-brand-700 rounded-md px-4 py-2 text-sm font-medium text-white transition-colors disabled:bg-neutral-300"
-              :disabled="loading"
-            >
-              {{ loading ? 'Enregistrement…' : 'Enregistrer' }}
-            </button>
-          </div>
-        </form>
-      </div>
-    </Teleport>
+    <AppModal
+      :open="showForm"
+      :title="editing ? 'Modifier l’adresse' : 'Nouvelle adresse'"
+      @close="showForm = false"
+    >
+      <AppAddressForm
+        v-model="form"
+        :loading="loading"
+        :error-message="errorMessage"
+        :submit-label="editing ? 'Enregistrer les changements' : 'Ajouter cette adresse'"
+        @submit="saveAddress"
+        @cancel="showForm = false"
+      />
+    </AppModal>
   </section>
 </template>

--- a/apps/storefront/app/pages/account/index.vue
+++ b/apps/storefront/app/pages/account/index.vue
@@ -1,20 +1,38 @@
 <script setup lang="ts">
+import { countryName } from '~~/app/data/countries'
+
 definePageMeta({ middleware: 'auth' })
 useHead({ title: 'Mon compte — Althea Systems' })
 
 const { user } = useAuth()
 const auth = useAuthApi()
+const account = useAccountApi()
+const checkoutApi = useCheckoutApi()
 const router = useRouter()
+const toast = useToast()
 
-const sections = [
-  { to: '/account/settings', label: 'Paramètres', description: 'Nom, email, mot de passe.' },
-  { to: '/account/addresses', label: 'Adresses', description: 'Carnet d’adresses de facturation et livraison.' },
-  { to: '/account/payment-methods', label: 'Moyens de paiement', description: 'Cartes enregistrées via Stripe.' },
-  { to: '/account/orders', label: 'Mes commandes', description: 'Historique de vos achats.' },
-]
+const [addressesResult, paymentsResult, ordersResult] = await Promise.all([
+  account.listAddresses().catch(() => []),
+  account.listPaymentMethods().catch(() => []),
+  checkoutApi.listOrders().catch(() => []),
+])
+
+const defaultShipping = computed(
+  () => addressesResult.find((a) => a.type === 'shipping' && a.isDefault) ?? addressesResult.find((a) => a.type === 'shipping')
+)
+const defaultBilling = computed(
+  () => addressesResult.find((a) => a.type === 'billing' && a.isDefault) ?? addressesResult.find((a) => a.type === 'billing')
+)
+const defaultCard = computed(
+  () => paymentsResult.find((p) => p.isDefault) ?? paymentsResult[0] ?? null
+)
+const lastOrder = computed(() => ordersResult[0] ?? null)
+const formatDate = (value: string | null) =>
+  value ? new Date(value).toLocaleDateString('fr-FR') : '—'
 
 async function onLogout() {
   await auth.logout()
+  toast.success('Vous êtes déconnecté.')
   await router.replace('/')
 }
 </script>
@@ -38,13 +56,77 @@ async function onLogout() {
     </header>
 
     <ul class="mt-10 grid grid-cols-1 gap-4 md:grid-cols-2">
-      <li v-for="section in sections" :key="section.to">
+      <li>
         <NuxtLink
-          :to="section.to"
-          class="block rounded-xl border border-neutral-100 bg-white p-6 transition-shadow hover:shadow-md"
+          to="/account/settings"
+          class="block h-full rounded-xl border border-neutral-100 bg-white p-6 transition-shadow hover:shadow-md"
         >
-          <h2 class="font-display text-h3 font-medium text-brand-text">{{ section.label }}</h2>
-          <p class="mt-2 text-sm text-neutral-600">{{ section.description }}</p>
+          <div class="flex items-start justify-between">
+            <h2 class="font-display text-h3 font-medium text-brand-text">Paramètres</h2>
+            <span class="text-brand-500">→</span>
+          </div>
+          <p class="mt-2 text-sm text-neutral-600">{{ user?.email }}</p>
+          <p v-if="user?.phone" class="mt-1 text-sm text-neutral-500">{{ user.phone }}</p>
+          <p v-else class="mt-1 text-caption text-neutral-400">Téléphone non renseigné</p>
+        </NuxtLink>
+      </li>
+
+      <li>
+        <NuxtLink
+          to="/account/addresses"
+          class="block h-full rounded-xl border border-neutral-100 bg-white p-6 transition-shadow hover:shadow-md"
+        >
+          <div class="flex items-start justify-between">
+            <h2 class="font-display text-h3 font-medium text-brand-text">Adresses</h2>
+            <span class="text-brand-500">→</span>
+          </div>
+          <div v-if="defaultShipping" class="mt-2 text-sm text-neutral-600">
+            <p>{{ defaultShipping.fullName }}</p>
+            <p>{{ defaultShipping.street }}</p>
+            <p>{{ defaultShipping.postalCode }} {{ defaultShipping.city }}, {{ countryName(defaultShipping.country) }}</p>
+          </div>
+          <p v-else class="text-caption mt-2 text-neutral-400">
+            Aucune adresse de livraison · cliquez pour en ajouter une
+          </p>
+        </NuxtLink>
+      </li>
+
+      <li>
+        <NuxtLink
+          to="/account/payment-methods"
+          class="block h-full rounded-xl border border-neutral-100 bg-white p-6 transition-shadow hover:shadow-md"
+        >
+          <div class="flex items-start justify-between">
+            <h2 class="font-display text-h3 font-medium text-brand-text">Moyens de paiement</h2>
+            <span class="text-brand-500">→</span>
+          </div>
+          <p v-if="defaultCard" class="mt-2 text-sm text-neutral-600 capitalize">
+            {{ defaultCard.brand }} •••• {{ defaultCard.lastFour }}
+            <span v-if="defaultCard.expMonth && defaultCard.expYear" class="text-neutral-400">
+              · {{ String(defaultCard.expMonth).padStart(2, '0') }}/{{ defaultCard.expYear }}
+            </span>
+          </p>
+          <p v-else class="text-caption mt-2 text-neutral-400">
+            Aucune carte enregistrée · cliquez pour en ajouter une
+          </p>
+        </NuxtLink>
+      </li>
+
+      <li>
+        <NuxtLink
+          to="/account/orders"
+          class="block h-full rounded-xl border border-neutral-100 bg-white p-6 transition-shadow hover:shadow-md"
+        >
+          <div class="flex items-start justify-between">
+            <h2 class="font-display text-h3 font-medium text-brand-text">Mes commandes</h2>
+            <span class="text-brand-500">→</span>
+          </div>
+          <p class="mt-2 text-sm text-neutral-600">
+            {{ ordersResult.length }} commande{{ ordersResult.length > 1 ? 's' : '' }} passée{{ ordersResult.length > 1 ? 's' : '' }}
+          </p>
+          <p v-if="lastOrder" class="text-caption mt-1 text-neutral-500">
+            Dernière : {{ formatDate(lastOrder.placedAt ?? lastOrder.createdAt) }}
+          </p>
         </NuxtLink>
       </li>
     </ul>

--- a/apps/storefront/app/pages/account/payment-methods.vue
+++ b/apps/storefront/app/pages/account/payment-methods.vue
@@ -5,18 +5,24 @@ definePageMeta({ middleware: 'auth' })
 useHead({ title: 'Moyens de paiement — Althea Systems' })
 
 const account = useAccountApi()
+const toast = useToast()
 
 const methods = ref<PaymentMethod[]>([])
 const showForm = ref(false)
 const errorMessage = ref<string | null>(null)
 const setupClientSecret = ref<string | null>(null)
 const setAsDefault = ref(false)
+const initialLoading = ref(true)
 
 async function refresh() {
   methods.value = await account.listPaymentMethods()
 }
 
-await refresh()
+try {
+  await refresh()
+} finally {
+  initialLoading.value = false
+}
 
 async function openCreate() {
   errorMessage.value = null
@@ -26,7 +32,7 @@ async function openCreate() {
     setupClientSecret.value = intent.clientSecret
     showForm.value = true
   } catch (err) {
-    errorMessage.value = extractFirstError(err) ?? 'Impossible de préparer Stripe.'
+    toast.error(extractFirstError(err) ?? 'Impossible de préparer Stripe.')
   }
 }
 
@@ -40,6 +46,7 @@ async function onCardSuccess(paymentMethodId: string) {
     await refresh()
     showForm.value = false
     setupClientSecret.value = null
+    toast.success('Carte enregistrée.')
   } catch (err) {
     errorMessage.value = extractFirstError(err) ?? 'Une erreur est survenue.'
   }
@@ -50,14 +57,24 @@ function onCardError(message: string) {
 }
 
 async function setDefault(id: number) {
-  await account.setDefaultPaymentMethod(id)
-  await refresh()
+  try {
+    await account.setDefaultPaymentMethod(id)
+    await refresh()
+    toast.success('Carte par défaut mise à jour.')
+  } catch (err) {
+    toast.error(extractFirstError(err) ?? 'Mise à jour impossible.')
+  }
 }
 
 async function removeMethod(id: number) {
   if (!confirm('Supprimer cette carte ?')) return
-  await account.deletePaymentMethod(id)
-  await refresh()
+  try {
+    await account.deletePaymentMethod(id)
+    await refresh()
+    toast.success('Carte supprimée.')
+  } catch (err) {
+    toast.error(extractFirstError(err) ?? 'Suppression impossible.')
+  }
 }
 </script>
 
@@ -67,8 +84,14 @@ async function removeMethod(id: number) {
       ← Mon compte
     </NuxtLink>
     <header class="mt-2 flex flex-wrap items-end justify-between gap-4">
-      <h1 class="font-display text-h1 font-medium text-brand-text">Moyens de paiement</h1>
+      <div>
+        <h1 class="font-display text-h1 font-medium text-brand-text">Moyens de paiement</h1>
+        <p class="mt-2 text-sm text-neutral-600">
+          Aucune donnée bancaire sensible n’est stockée — les cartes sont enregistrées via Stripe.
+        </p>
+      </div>
       <button
+        v-if="methods.length"
         type="button"
         class="bg-brand-500 hover:bg-brand-700 rounded-md px-4 py-2 text-sm font-medium text-white transition-colors"
         @click="openCreate"
@@ -77,12 +100,12 @@ async function removeMethod(id: number) {
       </button>
     </header>
 
-    <p class="mt-2 text-sm text-neutral-500">
-      Aucune donnée bancaire sensible n’est stockée sur nos serveurs — les cartes sont enregistrées
-      via Stripe.
-    </p>
+    <div v-if="initialLoading" class="mt-8 grid gap-4 md:grid-cols-2">
+      <AppSkeleton class="h-32" />
+      <AppSkeleton class="h-32" />
+    </div>
 
-    <ul v-if="methods.length" class="mt-8 grid gap-4 md:grid-cols-2">
+    <ul v-else-if="methods.length" class="mt-8 grid gap-4 md:grid-cols-2">
       <li
         v-for="method in methods"
         :key="method.id"
@@ -115,7 +138,7 @@ async function removeMethod(id: number) {
           </button>
           <button
             type="button"
-            class="rounded-md border border-neutral-200 px-3 py-1 text-neutral-700 hover:border-danger hover:text-danger"
+            class="hover:border-danger hover:text-danger rounded-md border border-neutral-200 px-3 py-1 text-neutral-700"
             @click="removeMethod(method.id)"
           >
             Supprimer
@@ -124,52 +147,53 @@ async function removeMethod(id: number) {
       </li>
     </ul>
 
-    <p v-else class="mt-8 text-sm text-neutral-500">
-      Vous n’avez pas encore enregistré de carte.
-    </p>
-
-    <Teleport to="body">
-      <div
-        v-if="showForm"
-        class="fixed inset-0 z-50 flex items-center justify-center bg-neutral-900/50 p-4"
-        @click.self="showForm = false"
+    <div
+      v-else
+      class="bg-brand-50 mt-8 flex flex-col items-center justify-center rounded-xl border border-dashed border-brand-300 py-16 text-center"
+    >
+      <svg viewBox="0 0 24 24" class="text-brand-500 mb-4 h-10 w-10" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+        <rect x="3" y="6" width="18" height="13" rx="2" />
+        <path d="M3 11h18" />
+      </svg>
+      <h2 class="font-display text-h3 font-medium text-brand-text">Aucune carte enregistrée</h2>
+      <p class="mt-2 max-w-sm text-sm text-neutral-600">
+        Ajoutez une carte pour finaliser vos commandes en un clic.
+      </p>
+      <button
+        type="button"
+        class="bg-brand-500 hover:bg-brand-700 mt-6 rounded-md px-5 py-3 text-sm font-medium text-white transition-colors"
+        @click="openCreate"
       >
-        <div class="max-h-full w-full max-w-md overflow-y-auto rounded-xl bg-white p-6">
-          <h2 class="font-display text-h3 font-medium text-brand-text">Nouvelle carte</h2>
-          <p class="mt-2 text-caption text-neutral-500">
-            Saisissez les informations de votre carte. Le test Stripe accepte
-            <code>4242 4242 4242 4242</code>, n’importe quelle date future et n’importe quel CVC.
-          </p>
+        Ajouter ma première carte
+      </button>
+    </div>
 
-          <div class="mt-4">
-            <AppStripeCardForm
-              v-if="setupClientSecret"
-              :client-secret="setupClientSecret"
-              @success="onCardSuccess"
-              @error="onCardError"
-            />
-          </div>
+    <AppModal :open="showForm" title="Nouvelle carte" @close="showForm = false">
+      <p class="text-sm text-neutral-600">
+        Saisissez les informations de votre carte. En mode test Stripe, utilisez
+        <code class="rounded bg-neutral-100 px-1 py-0.5 text-xs">4242 4242 4242 4242</code>,
+        n’importe quelle date future et n’importe quel CVC.
+      </p>
 
-          <label class="mt-4 inline-flex items-center gap-2 text-sm text-neutral-700">
-            <input
-              v-model="setAsDefault"
-              type="checkbox"
-              class="accent-brand-500 h-4 w-4 rounded border-neutral-300"
-            />
-            Définir par défaut
-          </label>
-
-          <AppFormError :message="errorMessage" />
-
-          <button
-            type="button"
-            class="mt-4 w-full rounded-md border border-neutral-200 px-4 py-2 text-sm text-neutral-700"
-            @click="showForm = false"
-          >
-            Annuler
-          </button>
-        </div>
+      <div class="mt-6">
+        <AppStripeCardForm
+          v-if="setupClientSecret"
+          :client-secret="setupClientSecret"
+          @success="onCardSuccess"
+          @error="onCardError"
+        />
       </div>
-    </Teleport>
+
+      <label class="mt-4 inline-flex items-center gap-2 text-sm text-neutral-700">
+        <input
+          v-model="setAsDefault"
+          type="checkbox"
+          class="accent-brand-500 h-4 w-4 rounded border-neutral-300"
+        />
+        Définir par défaut
+      </label>
+
+      <AppFormError :message="errorMessage" />
+    </AppModal>
   </section>
 </template>

--- a/apps/storefront/app/pages/account/settings.vue
+++ b/apps/storefront/app/pages/account/settings.vue
@@ -4,16 +4,15 @@ useHead({ title: 'Paramètres — Althea Systems' })
 
 const account = useAccountApi()
 const { user, setUser } = useAuth()
+const toast = useToast()
 
 const fullName = ref(user.value?.fullName ?? '')
 const phone = ref(user.value?.phone ?? '')
-const profileMessage = ref<string | null>(null)
 const profileError = ref<string | null>(null)
 const profileLoading = ref(false)
 
 async function saveProfile() {
   profileError.value = null
-  profileMessage.value = null
   profileLoading.value = true
   try {
     const response = await account.updateProfile({
@@ -21,7 +20,7 @@ async function saveProfile() {
       phone: phone.value || null,
     })
     setUser(response.user)
-    profileMessage.value = 'Profil mis à jour.'
+    toast.success('Profil mis à jour.')
   } catch (err) {
     profileError.value = extractFirstError(err) ?? 'Une erreur est survenue.'
   } finally {
@@ -31,20 +30,18 @@ async function saveProfile() {
 
 const newEmail = ref('')
 const emailPassword = ref('')
-const emailMessage = ref<string | null>(null)
 const emailError = ref<string | null>(null)
 const emailLoading = ref(false)
 
 async function saveEmail() {
   emailError.value = null
-  emailMessage.value = null
   emailLoading.value = true
   try {
     const response = await account.changeEmail({
       email: newEmail.value,
       currentPassword: emailPassword.value,
     })
-    emailMessage.value = response.message
+    toast.success(response.message)
     newEmail.value = ''
     emailPassword.value = ''
   } catch (err) {
@@ -56,20 +53,18 @@ async function saveEmail() {
 
 const currentPassword = ref('')
 const newPassword = ref('')
-const passwordMessage = ref<string | null>(null)
 const passwordError = ref<string | null>(null)
 const passwordLoading = ref(false)
 
 async function savePassword() {
   passwordError.value = null
-  passwordMessage.value = null
   passwordLoading.value = true
   try {
     const response = await account.changePassword({
       currentPassword: currentPassword.value,
       newPassword: newPassword.value,
     })
-    passwordMessage.value = response.message
+    toast.success(response.message)
     currentPassword.value = ''
     newPassword.value = ''
   } catch (err) {
@@ -84,9 +79,14 @@ const router = useRouter()
 
 async function deactivate() {
   if (!confirm('Confirmer la désactivation de votre compte ?')) return
-  await account.deactivate()
-  await auth.logout()
-  await router.replace('/')
+  try {
+    await account.deactivate()
+    await auth.logout()
+    toast.success('Votre compte a été désactivé.')
+    await router.replace('/')
+  } catch (err) {
+    toast.error(extractFirstError(err) ?? 'Désactivation impossible.')
+  }
 }
 </script>
 
@@ -97,31 +97,34 @@ async function deactivate() {
     </NuxtLink>
     <h1 class="font-display text-h1 mt-2 font-medium text-brand-text">Paramètres</h1>
 
-    <div class="mt-10 space-y-12">
-      <form class="space-y-4 rounded-xl border border-neutral-100 bg-white p-6" @submit.prevent="saveProfile">
-        <h2 class="font-display text-h3 font-medium text-brand-text">Informations personnelles</h2>
+    <div class="mt-10 space-y-8">
+      <form class="space-y-5 rounded-xl border border-neutral-100 bg-white p-6" @submit.prevent="saveProfile">
+        <div>
+          <h2 class="font-display text-h3 font-medium text-brand-text">Informations personnelles</h2>
+          <p class="mt-1 text-sm text-neutral-600">Mettez à jour vos coordonnées de contact.</p>
+        </div>
 
-        <label class="block">
-          <span class="text-caption text-neutral-500 uppercase">Nom complet</span>
-          <input
-            v-model="fullName"
-            type="text"
-            class="mt-1 w-full rounded-md border border-neutral-200 bg-white px-3 py-2 text-sm focus:border-brand-500 focus:outline-none"
-          />
-        </label>
+        <div class="grid gap-4 md:grid-cols-2">
+          <label class="block">
+            <span class="text-caption text-neutral-500 uppercase tracking-wide">Nom complet</span>
+            <input
+              v-model="fullName"
+              type="text"
+              autocomplete="name"
+              class="mt-1 w-full rounded-md border border-neutral-200 bg-white px-3 py-2 text-sm focus:border-brand-500 focus:outline-none"
+            />
+          </label>
+          <label class="block">
+            <span class="text-caption text-neutral-500 uppercase tracking-wide">Téléphone</span>
+            <input
+              v-model="phone"
+              type="tel"
+              autocomplete="tel"
+              class="mt-1 w-full rounded-md border border-neutral-200 bg-white px-3 py-2 text-sm focus:border-brand-500 focus:outline-none"
+            />
+          </label>
+        </div>
 
-        <label class="block">
-          <span class="text-caption text-neutral-500 uppercase">Téléphone</span>
-          <input
-            v-model="phone"
-            type="tel"
-            class="mt-1 w-full rounded-md border border-neutral-200 bg-white px-3 py-2 text-sm focus:border-brand-500 focus:outline-none"
-          />
-        </label>
-
-        <p v-if="profileMessage" class="bg-success/10 text-success rounded-md px-3 py-2 text-sm">
-          {{ profileMessage }}
-        </p>
         <AppFormError :message="profileError" />
 
         <button
@@ -133,33 +136,34 @@ async function deactivate() {
         </button>
       </form>
 
-      <form class="space-y-4 rounded-xl border border-neutral-100 bg-white p-6" @submit.prevent="saveEmail">
-        <h2 class="font-display text-h3 font-medium text-brand-text">Adresse email</h2>
-        <p class="text-sm text-neutral-600">Adresse actuelle : {{ user?.email }}</p>
+      <form class="space-y-5 rounded-xl border border-neutral-100 bg-white p-6" @submit.prevent="saveEmail">
+        <div>
+          <h2 class="font-display text-h3 font-medium text-brand-text">Adresse email</h2>
+          <p class="mt-1 text-sm text-neutral-600">Adresse actuelle : <span class="text-brand-text font-medium">{{ user?.email }}</span></p>
+        </div>
 
-        <label class="block">
-          <span class="text-caption text-neutral-500 uppercase">Nouvelle adresse</span>
-          <input
-            v-model="newEmail"
-            type="email"
-            required
-            class="mt-1 w-full rounded-md border border-neutral-200 bg-white px-3 py-2 text-sm focus:border-brand-500 focus:outline-none"
-          />
-        </label>
+        <div class="grid gap-4 md:grid-cols-2">
+          <label class="block">
+            <span class="text-caption text-neutral-500 uppercase tracking-wide">Nouvelle adresse</span>
+            <input
+              v-model="newEmail"
+              type="email"
+              required
+              class="mt-1 w-full rounded-md border border-neutral-200 bg-white px-3 py-2 text-sm focus:border-brand-500 focus:outline-none"
+            />
+          </label>
+          <label class="block">
+            <span class="text-caption text-neutral-500 uppercase tracking-wide">Mot de passe actuel</span>
+            <input
+              v-model="emailPassword"
+              type="password"
+              autocomplete="current-password"
+              required
+              class="mt-1 w-full rounded-md border border-neutral-200 bg-white px-3 py-2 text-sm focus:border-brand-500 focus:outline-none"
+            />
+          </label>
+        </div>
 
-        <label class="block">
-          <span class="text-caption text-neutral-500 uppercase">Mot de passe actuel</span>
-          <input
-            v-model="emailPassword"
-            type="password"
-            required
-            class="mt-1 w-full rounded-md border border-neutral-200 bg-white px-3 py-2 text-sm focus:border-brand-500 focus:outline-none"
-          />
-        </label>
-
-        <p v-if="emailMessage" class="bg-success/10 text-success rounded-md px-3 py-2 text-sm">
-          {{ emailMessage }}
-        </p>
         <AppFormError :message="emailError" />
 
         <button
@@ -171,33 +175,36 @@ async function deactivate() {
         </button>
       </form>
 
-      <form class="space-y-4 rounded-xl border border-neutral-100 bg-white p-6" @submit.prevent="savePassword">
-        <h2 class="font-display text-h3 font-medium text-brand-text">Mot de passe</h2>
+      <form class="space-y-5 rounded-xl border border-neutral-100 bg-white p-6" @submit.prevent="savePassword">
+        <div>
+          <h2 class="font-display text-h3 font-medium text-brand-text">Mot de passe</h2>
+          <p class="mt-1 text-sm text-neutral-600">8 caractères minimum.</p>
+        </div>
 
-        <label class="block">
-          <span class="text-caption text-neutral-500 uppercase">Mot de passe actuel</span>
-          <input
-            v-model="currentPassword"
-            type="password"
-            required
-            class="mt-1 w-full rounded-md border border-neutral-200 bg-white px-3 py-2 text-sm focus:border-brand-500 focus:outline-none"
-          />
-        </label>
+        <div class="grid gap-4 md:grid-cols-2">
+          <label class="block">
+            <span class="text-caption text-neutral-500 uppercase tracking-wide">Mot de passe actuel</span>
+            <input
+              v-model="currentPassword"
+              type="password"
+              autocomplete="current-password"
+              required
+              class="mt-1 w-full rounded-md border border-neutral-200 bg-white px-3 py-2 text-sm focus:border-brand-500 focus:outline-none"
+            />
+          </label>
+          <label class="block">
+            <span class="text-caption text-neutral-500 uppercase tracking-wide">Nouveau mot de passe</span>
+            <input
+              v-model="newPassword"
+              type="password"
+              autocomplete="new-password"
+              minlength="8"
+              required
+              class="mt-1 w-full rounded-md border border-neutral-200 bg-white px-3 py-2 text-sm focus:border-brand-500 focus:outline-none"
+            />
+          </label>
+        </div>
 
-        <label class="block">
-          <span class="text-caption text-neutral-500 uppercase">Nouveau mot de passe</span>
-          <input
-            v-model="newPassword"
-            type="password"
-            minlength="8"
-            required
-            class="mt-1 w-full rounded-md border border-neutral-200 bg-white px-3 py-2 text-sm focus:border-brand-500 focus:outline-none"
-          />
-        </label>
-
-        <p v-if="passwordMessage" class="bg-success/10 text-success rounded-md px-3 py-2 text-sm">
-          {{ passwordMessage }}
-        </p>
         <AppFormError :message="passwordError" />
 
         <button
@@ -216,7 +223,7 @@ async function deactivate() {
         </p>
         <button
           type="button"
-          class="bg-danger mt-4 inline-flex rounded-md px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-danger/90"
+          class="bg-danger mt-4 inline-flex rounded-md px-4 py-2 text-sm font-medium text-white transition-colors hover:opacity-90"
           @click="deactivate"
         >
           Désactiver mon compte

--- a/apps/storefront/app/pages/cart.vue
+++ b/apps/storefront/app/pages/cart.vue
@@ -4,6 +4,7 @@ useHead({ title: 'Panier — Althea Systems' })
 const cart = useCart()
 const checkoutApi = useCheckoutApi()
 const { isAuthenticated } = useAuth()
+const toast = useToast()
 
 const quote = ref<Awaited<ReturnType<typeof checkoutApi.quote>> | null>(null)
 const loading = ref(false)
@@ -32,6 +33,18 @@ function lineFor(productId: number) {
   return quote.value?.lines.find((line) => line.productId === productId) ?? null
 }
 
+function removeUnavailable() {
+  for (const line of quote.value?.unavailable ?? []) {
+    cart.remove(line.productId)
+  }
+  toast.info('Produits indisponibles retirés du panier.')
+}
+
+function onRemove(productId: number, name: string) {
+  cart.remove(productId)
+  toast.info(`${name} retiré du panier.`)
+}
+
 const formatPrice = (value: number) =>
   new Intl.NumberFormat('fr-FR', { style: 'currency', currency: 'EUR' }).format(value)
 
@@ -43,10 +56,26 @@ const canCheckout = computed(
 
 <template>
   <section class="mx-auto w-full max-w-[1200px] px-4 py-12 md:px-10 md:py-16">
-    <h1 class="font-display text-h1 font-medium text-brand-text">Mon panier</h1>
+    <div class="flex flex-wrap items-end justify-between gap-3">
+      <h1 class="font-display text-h1 font-medium text-brand-text">Mon panier</h1>
+      <NuxtLink to="/" class="text-sm text-neutral-500 hover:text-brand-500">
+        ← Continuer mes achats
+      </NuxtLink>
+    </div>
 
-    <div v-if="cart.isEmpty.value" class="mt-10 rounded-xl border border-neutral-100 p-8 text-center">
-      <p class="text-sm text-neutral-600">Votre panier est vide.</p>
+    <div
+      v-if="cart.isEmpty.value"
+      class="bg-brand-50 mt-10 flex flex-col items-center justify-center rounded-xl border border-dashed border-brand-300 py-16 text-center"
+    >
+      <svg viewBox="0 0 24 24" class="text-brand-500 mb-4 h-10 w-10" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M3 4h2.4l2.6 11h11l2-8H7" />
+        <circle cx="10" cy="20" r="1.4" fill="currentColor" />
+        <circle cx="18" cy="20" r="1.4" fill="currentColor" />
+      </svg>
+      <h2 class="font-display text-h3 font-medium text-brand-text">Votre panier est vide</h2>
+      <p class="mt-2 max-w-sm text-sm text-neutral-600">
+        Parcourez le catalogue et ajoutez vos produits pour les retrouver ici.
+      </p>
       <NuxtLink
         to="/"
         class="bg-brand-500 hover:bg-brand-700 mt-6 inline-flex rounded-md px-5 py-3 text-sm font-medium text-white transition-colors"
@@ -59,13 +88,23 @@ const canCheckout = computed(
       <div class="space-y-4">
         <div
           v-if="hasUnavailable"
-          class="bg-warning/10 text-warning rounded-md border border-warning/20 px-4 py-3 text-sm"
+          class="bg-warning/10 text-warning flex items-start justify-between gap-4 rounded-md border border-warning/20 px-4 py-3 text-sm"
         >
-          Certains produits ne sont plus disponibles. Retirez-les avant de passer à la caisse.
+          <span>
+            Certains produits ne sont plus disponibles. Retirez-les pour finaliser votre commande.
+          </span>
+          <button
+            type="button"
+            class="rounded-md border border-warning/40 px-3 py-1 text-xs font-medium hover:bg-warning/20"
+            @click="removeUnavailable"
+          >
+            Retirer tout
+          </button>
         </div>
+
         <ul class="divide-y divide-neutral-100 rounded-xl border border-neutral-100 bg-white">
-          <li v-for="item in cart.items.value" :key="item.productId" class="flex gap-4 p-4">
-            <div class="bg-brand-50 flex h-20 w-20 shrink-0 items-center justify-center rounded-lg">
+          <li v-for="item in cart.items.value" :key="item.productId" class="flex gap-4 p-5">
+            <div class="bg-brand-50 flex h-24 w-24 shrink-0 items-center justify-center rounded-lg">
               <span class="font-display text-brand-500 text-xs uppercase">
                 {{ item.name.charAt(0) }}
               </span>
@@ -85,36 +124,39 @@ const canCheckout = computed(
                   >
                     Indisponible
                   </p>
+                  <p v-else class="text-caption mt-1 text-neutral-500">
+                    {{ formatPrice(item.unitPrice) }} l’unité
+                  </p>
                 </div>
                 <button
                   type="button"
-                  class="text-caption text-neutral-500 hover:text-danger"
-                  @click="cart.remove(item.productId)"
+                  class="text-caption text-neutral-500 transition-colors hover:text-danger"
+                  @click="onRemove(item.productId, item.name)"
                 >
                   Retirer
                 </button>
               </div>
-              <div class="mt-3 flex items-center justify-between">
+              <div class="mt-4 flex items-center justify-between">
                 <div class="inline-flex items-center rounded-md border border-neutral-200">
                   <button
                     type="button"
-                    class="px-3 py-1 text-neutral-600 hover:text-brand-500"
-                    aria-label="Diminuer"
+                    class="px-4 py-2 text-base text-neutral-600 transition-colors hover:text-brand-500"
+                    aria-label="Diminuer la quantité"
                     @click="cart.setQuantity(item.productId, item.quantity - 1)"
                   >
                     −
                   </button>
-                  <span class="min-w-8 text-center text-sm">{{ item.quantity }}</span>
+                  <span class="min-w-10 text-center text-base font-medium">{{ item.quantity }}</span>
                   <button
                     type="button"
-                    class="px-3 py-1 text-neutral-600 hover:text-brand-500"
-                    aria-label="Augmenter"
+                    class="px-4 py-2 text-base text-neutral-600 transition-colors hover:text-brand-500"
+                    aria-label="Augmenter la quantité"
                     @click="cart.setQuantity(item.productId, item.quantity + 1)"
                   >
                     +
                   </button>
                 </div>
-                <p class="font-display text-brand-500 text-base">
+                <p class="font-display text-brand-500 text-lg">
                   {{ formatPrice(item.unitPrice * item.quantity) }}
                 </p>
               </div>
@@ -124,7 +166,9 @@ const canCheckout = computed(
         <AppFormError :message="errorMessage" />
       </div>
 
-      <aside class="rounded-xl border border-neutral-100 bg-white p-6">
+      <aside
+        class="rounded-xl border border-neutral-100 bg-white p-6 lg:sticky lg:top-24 lg:self-start"
+      >
         <h2 class="font-display text-h3 font-medium text-brand-text">Récapitulatif</h2>
         <dl class="mt-6 space-y-3 text-sm text-neutral-700">
           <div class="flex justify-between">
@@ -161,7 +205,7 @@ const canCheckout = computed(
           Passer à la caisse
         </button>
 
-        <p v-if="!isAuthenticated" class="mt-3 text-caption text-neutral-500">
+        <p v-if="!isAuthenticated" class="text-caption mt-3 text-neutral-500">
           Vous devrez vous connecter pour finaliser la commande.
         </p>
       </aside>

--- a/apps/storefront/app/pages/checkout/index.vue
+++ b/apps/storefront/app/pages/checkout/index.vue
@@ -88,13 +88,7 @@ const formatPrice = (value: number) =>
   <section class="mx-auto w-full max-w-[900px] px-4 py-12 md:px-10 md:py-16">
     <h1 class="font-display text-h1 font-medium text-brand-text">Finaliser ma commande</h1>
 
-    <ol class="text-caption mt-6 flex items-center gap-3 text-neutral-500 uppercase">
-      <li :class="step === 1 ? 'text-brand-500' : ''">1. Identification</li>
-      <li>›</li>
-      <li :class="step === 2 ? 'text-brand-500' : ''">2. Adresses</li>
-      <li>›</li>
-      <li :class="step === 3 ? 'text-brand-500' : ''">3. Paiement</li>
-    </ol>
+    <AppCheckoutSteps :current="step" />
 
     <section v-if="step === 1" class="mt-10 space-y-4 rounded-xl border border-neutral-100 bg-white p-6">
       <h2 class="font-display text-h3 font-medium text-brand-text">Identification</h2>


### PR DESCRIPTION
Adds shared UX primitives — useToast composable + AppToastHost auto-dismiss container, AppLoadingBar wired to Nuxt's useLoadingIndicator, AppSkeleton, AppModal that handles its own scroll lock and slides up from the bottom on mobile, AppCheckoutSteps with numbered circles and a done state, and an AppAddressForm that uses a real country select sourced from a hard-coded list of common ISO codes. The address book empty state is now a centered illustration with a single primary CTA, the modal uses the new shared component and the form has a two-column layout with autofocus on the first field and proper autocomplete hints. The account dashboard tiles now show a useful preview each (default shipping address, default card brand and last four, total order count and last order date). The cart page got bigger touch targets on the quantity controls, a Continuer mes achats link, a sticky summary on lg+, a better empty state and a one-click Retirer tout button when items become unavailable. The checkout page replaces its flat breadcrumb with the AppCheckoutSteps component. Settings and payment methods now use toasts instead of inline success boxes.