### PR TITLE
fix: attach payment methods to a stripe customer so saved cards show on checkout

### DIFF
--- a/apps/api/app/controllers/checkout_controller.ts
+++ b/apps/api/app/controllers/checkout_controller.ts
@@ -2,6 +2,7 @@ import type { HttpContext } from '@adonisjs/core/http'
 import { quoteValidator, createPaymentIntentValidator } from '#validators/checkout'
 import { quoteCart } from '#services/cart_pricing'
 import { stripeClient, stripeCurrency, toMinorUnits } from '#services/stripe_service'
+import { ensureStripeCustomer } from '#services/stripe_customer'
 
 export default class CheckoutController {
   async quote({ request }: HttpContext) {
@@ -25,9 +26,12 @@ export default class CheckoutController {
       return response.unprocessableEntity({ message: 'Panier vide.' })
     }
 
+    const customerId = await ensureStripeCustomer(user)
     const intent = await stripeClient().paymentIntents.create({
       amount: toMinorUnits(quote.total),
       currency: stripeCurrency(),
+      customer: customerId,
+      setup_future_usage: 'off_session',
       automatic_payment_methods: { enabled: true },
       metadata: { user_id: String(user.id) },
     })

--- a/apps/api/app/controllers/payment_methods_controller.ts
+++ b/apps/api/app/controllers/payment_methods_controller.ts
@@ -6,6 +6,7 @@ import {
   updatePaymentMethodValidator,
 } from '#validators/account'
 import { stripeClient } from '#services/stripe_service'
+import { ensureStripeCustomer } from '#services/stripe_customer'
 
 export default class PaymentMethodsController {
   async index({ auth }: HttpContext) {
@@ -18,7 +19,9 @@ export default class PaymentMethodsController {
 
   async setupIntent({ auth }: HttpContext) {
     const user = auth.getUserOrFail()
+    const customerId = await ensureStripeCustomer(user)
     const intent = await stripeClient().setupIntents.create({
+      customer: customerId,
       payment_method_types: ['card'],
       usage: 'off_session',
       metadata: { user_id: String(user.id), user_email: user.email },
@@ -78,6 +81,13 @@ export default class PaymentMethodsController {
       .where('id', params.id)
       .where('userId', user.id)
       .firstOrFail()
+
+    if (user.stripeCustomerId) {
+      try {
+        await stripeClient().paymentMethods.detach(method.stripePaymentMethodId)
+      } catch {}
+    }
+
     await method.delete()
     return response.noContent()
   }

--- a/apps/api/app/models/user.ts
+++ b/apps/api/app/models/user.ts
@@ -35,6 +35,9 @@ export default class User extends compose(BaseModel, AuthFinder) {
   @column()
   declare isActive: boolean
 
+  @column()
+  declare stripeCustomerId: string | null
+
   @column.dateTime({ autoCreate: true })
   declare createdAt: DateTime
 

--- a/apps/api/app/services/stripe_customer.ts
+++ b/apps/api/app/services/stripe_customer.ts
@@ -1,0 +1,36 @@
+import User from '#models/user'
+import PaymentMethod from '#models/payment_method'
+import logger from '@adonisjs/core/services/logger'
+import { stripeClient } from '#services/stripe_service'
+
+export async function ensureStripeCustomer(user: User): Promise<string> {
+  if (user.stripeCustomerId) return user.stripeCustomerId
+
+  const customer = await stripeClient().customers.create({
+    email: user.email,
+    name: user.fullName ?? undefined,
+    metadata: { user_id: String(user.id) },
+  })
+
+  user.stripeCustomerId = customer.id
+  await user.save()
+
+  await attachLegacyPaymentMethods(user.id, customer.id)
+  return customer.id
+}
+
+async function attachLegacyPaymentMethods(userId: number, customerId: string) {
+  const methods = await PaymentMethod.query().where('userId', userId)
+  for (const method of methods) {
+    try {
+      await stripeClient().paymentMethods.attach(method.stripePaymentMethodId, {
+        customer: customerId,
+      })
+    } catch (err) {
+      logger.warn(
+        { err, paymentMethodId: method.stripePaymentMethodId },
+        'failed to attach legacy payment method to stripe customer'
+      )
+    }
+  }
+}

--- a/apps/api/database/migrations/1773400000001_alter_users_add_stripe_customer_id.ts
+++ b/apps/api/database/migrations/1773400000001_alter_users_add_stripe_customer_id.ts
@@ -1,0 +1,17 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'users'
+
+  async up() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.string('stripe_customer_id').nullable().unique()
+    })
+  }
+
+  async down() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.dropColumn('stripe_customer_id')
+    })
+  }
+}


### PR DESCRIPTION
Stripe Elements only surfaces saved cards on the payment step when the PaymentIntent is associated with a customer that owns the cards, but the api was creating both SetupIntents and PaymentIntents without a customer, so saved cards lived as orphaned payment methods that Elements never proposed. Adds a stripe_customer_id column on users, an ensureStripeCustomer helper that lazily creates the customer on first card save or first checkout, and pipes the customer id through the SetupIntent and PaymentIntent flows. Existing payment methods saved before this change get re-attached automatically the first time their owner triggers ensureStripeCustomer.