### PR TITLE
feat(backoffice): dashboard kpi cards, alerts and quick actions

### DIFF
--- a/apps/api/app/controllers/admin_dashboard_controller.ts
+++ b/apps/api/app/controllers/admin_dashboard_controller.ts
@@ -1,0 +1,78 @@
+import type { HttpContext } from '@adonisjs/core/http'
+import { DateTime } from 'luxon'
+import db from '@adonisjs/lucid/services/db'
+import Order from '#models/order'
+
+const REVENUE_STATUSES = ['paid', 'processing', 'shipped', 'delivered']
+
+export default class AdminDashboardController {
+  async stats({}: HttpContext) {
+    const now = DateTime.now()
+    const startOfDay = now.startOf('day')
+    const startOfWeek = now.startOf('week')
+    const startOfMonth = now.startOf('month')
+
+    const [revenueDay, revenueWeek, revenueMonth, todayOrders, outOfStock, unreadMessages, recentOrders] =
+      await Promise.all([
+        sumRevenueSince(startOfDay),
+        sumRevenueSince(startOfWeek),
+        sumRevenueSince(startOfMonth),
+        countOrdersSince(startOfDay),
+        countOutOfStockProducts(),
+        countUnreadMessages(),
+        Order.query().orderBy('createdAt', 'desc').limit(5).preload('user'),
+      ])
+
+    return {
+      revenue: {
+        day: revenueDay,
+        week: revenueWeek,
+        month: revenueMonth,
+      },
+      todayOrders,
+      outOfStock,
+      unreadMessages,
+      recentOrders: recentOrders.map((order) => ({
+        id: order.id,
+        status: order.status,
+        total: order.total,
+        createdAt: order.createdAt,
+        customer: order.user?.fullName || order.user?.email || 'Client',
+      })),
+    }
+  }
+}
+
+async function sumRevenueSince(since: DateTime) {
+  const result = await db
+    .from('orders')
+    .whereIn('status', REVENUE_STATUSES)
+    .where('created_at', '>=', since.toSQL()!)
+    .sum({ total: 'total' })
+  return Number(result[0]?.total ?? 0)
+}
+
+async function countOrdersSince(since: DateTime) {
+  const result = await db
+    .from('orders')
+    .where('created_at', '>=', since.toSQL()!)
+    .count('* as total')
+  return Number(result[0]?.total ?? 0)
+}
+
+async function countOutOfStockProducts() {
+  const result = await db
+    .from('products')
+    .where('is_active', true)
+    .where('stock', '<=', 0)
+    .count('* as total')
+  return Number(result[0]?.total ?? 0)
+}
+
+async function countUnreadMessages() {
+  const result = await db
+    .from('contact_messages')
+    .where('is_read', false)
+    .count('* as total')
+  return Number(result[0]?.total ?? 0)
+}

--- a/apps/api/start/routes.ts
+++ b/apps/api/start/routes.ts
@@ -3,6 +3,7 @@ import { middleware } from './kernel.js'
 
 const AuthController = () => import('#controllers/auth_controller')
 const AdminAuthController = () => import('#controllers/admin_auth_controller')
+const AdminDashboardController = () => import('#controllers/admin_dashboard_controller')
 const PasswordResetsController = () => import('#controllers/password_resets_controller')
 const AccountController = () => import('#controllers/account_controller')
 const AddressesController = () => import('#controllers/addresses_controller')
@@ -80,6 +81,13 @@ router
       .use([middleware.auth(), middleware.admin()])
   })
   .prefix('/admin/auth')
+
+router
+  .group(() => {
+    router.get('stats', [AdminDashboardController, 'stats'])
+  })
+  .prefix('/admin/dashboard')
+  .use([middleware.auth(), middleware.admin()])
 
 router
   .group(() => {

--- a/apps/backoffice/app/composables/useFormat.ts
+++ b/apps/backoffice/app/composables/useFormat.ts
@@ -1,0 +1,19 @@
+const currencyFormatter = new Intl.NumberFormat('fr-FR', {
+  style: 'currency',
+  currency: 'EUR',
+  maximumFractionDigits: 2
+})
+
+const dateFormatter = new Intl.DateTimeFormat('fr-FR', {
+  day: '2-digit',
+  month: 'short',
+  hour: '2-digit',
+  minute: '2-digit'
+})
+
+export function useFormat() {
+  return {
+    currency: (value: number | string) => currencyFormatter.format(Number(value || 0)),
+    dateTime: (value: string | Date) => dateFormatter.format(new Date(value))
+  }
+}

--- a/apps/backoffice/app/pages/index.vue
+++ b/apps/backoffice/app/pages/index.vue
@@ -1,22 +1,157 @@
 <script setup lang="ts">
+interface DashboardStats {
+  revenue: { day: number, week: number, month: number }
+  todayOrders: number
+  outOfStock: number
+  unreadMessages: number
+  recentOrders: Array<{
+    id: number
+    status: string
+    total: number
+    createdAt: string
+    customer: string
+  }>
+}
+
+const api = useApi()
 const { user } = useAdminAuth()
+const { currency, dateTime } = useFormat()
+
+const { data: stats, pending, refresh } = await useAsyncData<DashboardStats>('admin-dashboard', () =>
+  api<DashboardStats>('/admin/dashboard/stats')
+)
+
+const kpiCards = computed(() => {
+  const s = stats.value
+  return [
+    { label: 'Revenu du jour', value: s ? currency(s.revenue.day) : '—', icon: 'i-lucide-banknote', color: 'primary' },
+    { label: 'Cette semaine', value: s ? currency(s.revenue.week) : '—', icon: 'i-lucide-calendar-days', color: 'primary' },
+    { label: 'Ce mois-ci', value: s ? currency(s.revenue.month) : '—', icon: 'i-lucide-trending-up', color: 'primary' },
+    { label: 'Commandes aujourd\'hui', value: s ? String(s.todayOrders) : '—', icon: 'i-lucide-shopping-bag', color: 'neutral' }
+  ] as const
+})
+
+const alerts = computed(() => {
+  const s = stats.value
+  return [
+    {
+      label: 'Produits en rupture',
+      value: s?.outOfStock ?? 0,
+      icon: 'i-lucide-package-x',
+      color: (s?.outOfStock ?? 0) > 0 ? 'error' : 'neutral',
+      to: '/products'
+    },
+    {
+      label: 'Messages non lus',
+      value: s?.unreadMessages ?? 0,
+      icon: 'i-lucide-mail',
+      color: (s?.unreadMessages ?? 0) > 0 ? 'warning' : 'neutral',
+      to: '/messages'
+    }
+  ] as const
+})
+
+const statusColor: Record<string, 'primary' | 'success' | 'warning' | 'error' | 'neutral'> = {
+  pending: 'warning',
+  paid: 'primary',
+  processing: 'primary',
+  shipped: 'primary',
+  delivered: 'success',
+  cancelled: 'error',
+  refunded: 'neutral'
+}
 </script>
 
 <template>
-  <UDashboardNavbar title="Tableau de bord" />
+  <UDashboardNavbar title="Tableau de bord">
+    <template #right>
+      <UButton
+        icon="i-lucide-refresh-cw"
+        variant="ghost"
+        color="neutral"
+        :loading="pending"
+        aria-label="Rafraîchir"
+        @click="refresh()"
+      />
+    </template>
+  </UDashboardNavbar>
+
   <UDashboardPanelContent>
     <div class="space-y-6">
-      <UCard>
-        <template #header>
-          <div>
-            <p class="text-sm text-muted">Bienvenue</p>
-            <h1 class="text-xl font-semibold">{{ user?.fullName || user?.email }}</h1>
+      <header>
+        <p class="text-sm text-muted">Bienvenue</p>
+        <h1 class="text-2xl font-semibold">{{ user?.fullName || user?.email }}</h1>
+      </header>
+
+      <section class="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <UCard v-for="kpi in kpiCards" :key="kpi.label">
+          <div class="flex items-start gap-3">
+            <div class="rounded-lg bg-elevated p-2">
+              <UIcon :name="kpi.icon" class="size-5 text-primary" />
+            </div>
+            <div>
+              <p class="text-sm text-muted">{{ kpi.label }}</p>
+              <p class="text-2xl font-semibold">{{ kpi.value }}</p>
+            </div>
           </div>
-        </template>
-        <p class="text-sm text-muted">
-          Le tableau de bord détaillé arrivera avec les KPI, les graphes de ventes et les actions rapides.
-        </p>
-      </UCard>
+        </UCard>
+      </section>
+
+      <section class="grid gap-4 md:grid-cols-2">
+        <UCard v-for="alert in alerts" :key="alert.label">
+          <div class="flex items-center justify-between gap-3">
+            <div class="flex items-center gap-3">
+              <UIcon :name="alert.icon" class="size-5" :class="alert.color === 'error' ? 'text-error' : alert.color === 'warning' ? 'text-warning' : 'text-muted'" />
+              <p class="font-medium">{{ alert.label }}</p>
+            </div>
+            <UBadge :color="alert.color" variant="subtle">{{ alert.value }}</UBadge>
+          </div>
+          <template #footer>
+            <UButton :to="alert.to" variant="ghost" color="neutral" size="sm" trailing-icon="i-lucide-arrow-right">
+              Voir le détail
+            </UButton>
+          </template>
+        </UCard>
+      </section>
+
+      <section class="grid gap-4 lg:grid-cols-3">
+        <UCard class="lg:col-span-2">
+          <template #header>
+            <div class="flex items-center justify-between">
+              <h2 class="font-semibold">Dernières commandes</h2>
+              <UButton to="/orders" variant="link" color="neutral" size="sm">Toutes les commandes</UButton>
+            </div>
+          </template>
+          <div v-if="stats?.recentOrders?.length" class="divide-y divide-default">
+            <div
+              v-for="order in stats.recentOrders"
+              :key="order.id"
+              class="flex items-center justify-between gap-3 py-3 first:pt-0 last:pb-0"
+            >
+              <div>
+                <p class="font-medium">#{{ order.id }} — {{ order.customer }}</p>
+                <p class="text-sm text-muted">{{ dateTime(order.createdAt) }}</p>
+              </div>
+              <div class="flex items-center gap-3">
+                <UBadge :color="statusColor[order.status] || 'neutral'" variant="subtle">{{ order.status }}</UBadge>
+                <span class="font-semibold">{{ currency(order.total) }}</span>
+              </div>
+            </div>
+          </div>
+          <p v-else class="text-sm text-muted">Aucune commande pour l'instant.</p>
+        </UCard>
+
+        <UCard>
+          <template #header>
+            <h2 class="font-semibold">Actions rapides</h2>
+          </template>
+          <div class="flex flex-col gap-2">
+            <UButton to="/orders/new" icon="i-lucide-plus-circle" color="primary" block>Nouvelle commande</UButton>
+            <UButton to="/products/new" icon="i-lucide-package-plus" variant="soft" block>Ajouter un produit</UButton>
+            <UButton to="/messages" icon="i-lucide-mails" variant="soft" color="neutral" block>Voir les messages</UButton>
+          </div>
+        </UCard>
+      </section>
     </div>
   </UDashboardPanelContent>
 </template>


### PR DESCRIPTION
Closes #25.

Adds /admin/dashboard/stats on the API returning revenue (today / week / month, computed only from paid+ statuses), today's order count, out-of-stock product count, unread contact messages and the 5 most recent orders with customer label.

Backoffice replaces the placeholder home page with KPI cards, two alert cards (out-of-stock, unread messages — colored red/yellow when non-zero), the recent orders list with status badges and amounts, and a quick-actions panel (new order, add product, view messages). useFormat composable centralises EUR currency and short fr-FR datetime formatting. A refresh button on the navbar re-runs the query.