### PR TITLE
fix(backoffice): pad dashboard and security panel content

### DIFF
--- a/apps/backoffice/app/pages/index.vue
+++ b/apps/backoffice/app/pages/index.vue
@@ -76,7 +76,7 @@ const statusColor: Record<string, 'primary' | 'success' | 'warning' | 'error' | 
     </template>
   </UDashboardNavbar>
 
-  <UDashboardPanelContent>
+  <UDashboardPanelContent class="p-4 sm:p-6">
     <div class="space-y-6">
       <header>
         <p class="text-sm text-muted">Bienvenue</p>

--- a/apps/backoffice/app/pages/security.vue
+++ b/apps/backoffice/app/pages/security.vue
@@ -76,7 +76,7 @@ function extractMessage(err: unknown, fallback: string) {
 
 <template>
   <UDashboardNavbar title="Sécurité" />
-  <UDashboardPanelContent>
+  <UDashboardPanelContent class="p-4 sm:p-6">
     <div class="grid gap-6 max-w-3xl">
       <UCard>
         <template #header>


### PR DESCRIPTION
Adds p-4 sm:p-6 on UDashboardPanelContent so cards no longer sit flush against the sidebar and right edge.