### PR TITLE
feat(backoffice): sales charts with chart.js

### DIFF
--- a/apps/api/app/controllers/admin_dashboard_controller.ts
+++ b/apps/api/app/controllers/admin_dashboard_controller.ts
@@ -2,8 +2,10 @@ import type { HttpContext } from '@adonisjs/core/http'
 import { DateTime } from 'luxon'
 import db from '@adonisjs/lucid/services/db'
 import Order from '#models/order'
+import { salesRangeValidator } from '#validators/admin_dashboard'
 
 const REVENUE_STATUSES = ['paid', 'processing', 'shipped', 'delivered']
+const UNCATEGORIZED_LABEL = 'Sans catégorie'
 
 export default class AdminDashboardController {
   async stats({}: HttpContext) {
@@ -41,6 +43,98 @@ export default class AdminDashboardController {
       })),
     }
   }
+
+  async sales({ request }: HttpContext) {
+    const { range = '7d' } = await request.validateUsing(salesRangeValidator)
+    const buckets = range === '5w' ? buildWeekBuckets(5) : buildDayBuckets(7)
+    const since = buckets[0].start
+
+    const rows = await db
+      .from('order_items')
+      .innerJoin('orders', 'orders.id', 'order_items.order_id')
+      .leftJoin('products', 'products.id', 'order_items.product_id')
+      .leftJoin('categories', 'categories.id', 'products.category_id')
+      .whereIn('orders.status', REVENUE_STATUSES)
+      .where('orders.created_at', '>=', since.toSQL()!)
+      .select(
+        db.raw('orders.created_at as order_created_at'),
+        db.raw('coalesce(categories.name, ?) as category_name', [UNCATEGORIZED_LABEL]),
+        db.raw('order_items.total::numeric as total')
+      )
+
+    const categoryTotals = new Map<string, number>()
+    const stackByCategory = new Map<string, number[]>()
+    const bucketTotals = new Array(buckets.length).fill(0)
+
+    for (const row of rows) {
+      const itemTotal = Number(row.total ?? 0)
+      const category = row.category_name as string
+      const placedAt = DateTime.fromJSDate(new Date(row.order_created_at))
+      const idx = findBucketIndex(buckets, placedAt)
+      if (idx === -1) continue
+
+      bucketTotals[idx] += itemTotal
+      categoryTotals.set(category, (categoryTotals.get(category) ?? 0) + itemTotal)
+
+      const series = stackByCategory.get(category) ?? new Array(buckets.length).fill(0)
+      series[idx] += itemTotal
+      stackByCategory.set(category, series)
+    }
+
+    return {
+      range,
+      bucketLabels: buckets.map((b) => b.label),
+      totals: bucketTotals.map(round2),
+      byCategory: [...categoryTotals.entries()]
+        .map(([name, total]) => ({ name, total: round2(total) }))
+        .sort((a, b) => b.total - a.total),
+      stackedByCategory: [...stackByCategory.entries()]
+        .map(([name, values]) => ({ name, values: values.map(round2) }))
+        .sort((a, b) => sumArray(b.values) - sumArray(a.values)),
+    }
+  }
+}
+
+interface Bucket {
+  start: DateTime
+  end: DateTime
+  label: string
+}
+
+function buildDayBuckets(count: number): Bucket[] {
+  const today = DateTime.now().startOf('day')
+  return Array.from({ length: count }, (_, i) => {
+    const start = today.minus({ days: count - 1 - i })
+    return {
+      start,
+      end: start.plus({ days: 1 }),
+      label: start.setLocale('fr').toFormat('ccc dd/LL'),
+    }
+  })
+}
+
+function buildWeekBuckets(count: number): Bucket[] {
+  const thisWeek = DateTime.now().startOf('week')
+  return Array.from({ length: count }, (_, i) => {
+    const start = thisWeek.minus({ weeks: count - 1 - i })
+    return {
+      start,
+      end: start.plus({ weeks: 1 }),
+      label: `S${start.weekNumber}`,
+    }
+  })
+}
+
+function findBucketIndex(buckets: Bucket[], when: DateTime) {
+  return buckets.findIndex((b) => when >= b.start && when < b.end)
+}
+
+function round2(value: number) {
+  return Math.round(value * 100) / 100
+}
+
+function sumArray(values: number[]) {
+  return values.reduce((acc, v) => acc + v, 0)
 }
 
 async function sumRevenueSince(since: DateTime) {

--- a/apps/api/app/validators/admin_dashboard.ts
+++ b/apps/api/app/validators/admin_dashboard.ts
@@ -1,0 +1,7 @@
+import vine from '@vinejs/vine'
+
+export const salesRangeValidator = vine.compile(
+  vine.object({
+    range: vine.enum(['7d', '5w'] as const).optional()
+  })
+)

--- a/apps/api/start/routes.ts
+++ b/apps/api/start/routes.ts
@@ -85,6 +85,7 @@ router
 router
   .group(() => {
     router.get('stats', [AdminDashboardController, 'stats'])
+    router.get('sales', [AdminDashboardController, 'sales'])
   })
   .prefix('/admin/dashboard')
   .use([middleware.auth(), middleware.admin()])

--- a/apps/backoffice/app/components/SalesCharts.vue
+++ b/apps/backoffice/app/components/SalesCharts.vue
@@ -1,0 +1,152 @@
+<script setup lang="ts">
+import {
+  Chart as ChartJS,
+  ArcElement,
+  Tooltip,
+  Legend,
+  Title,
+  CategoryScale,
+  LinearScale,
+  BarElement
+} from 'chart.js'
+import { Bar, Doughnut } from 'vue-chartjs'
+
+ChartJS.register(ArcElement, Tooltip, Legend, Title, CategoryScale, LinearScale, BarElement)
+
+interface SalesPayload {
+  range: '7d' | '5w'
+  bucketLabels: string[]
+  totals: number[]
+  byCategory: Array<{ name: string, total: number }>
+  stackedByCategory: Array<{ name: string, values: number[] }>
+}
+
+const PALETTE = [
+  '#16a34a', '#2563eb', '#f97316', '#a855f7', '#0ea5e9',
+  '#dc2626', '#facc15', '#14b8a6', '#ec4899', '#64748b'
+]
+
+const api = useApi()
+const range = ref<'7d' | '5w'>('7d')
+
+const { data, pending, refresh } = await useAsyncData<SalesPayload>(
+  'admin-sales',
+  () => api<SalesPayload>('/admin/dashboard/sales', { params: { range: range.value } }),
+  { watch: [range] }
+)
+
+const colorFor = (i: number) => PALETTE[i % PALETTE.length]
+
+const pieData = computed(() => ({
+  labels: data.value?.byCategory.map((c) => c.name) ?? [],
+  datasets: [
+    {
+      data: data.value?.byCategory.map((c) => c.total) ?? [],
+      backgroundColor: (data.value?.byCategory ?? []).map((_, i) => colorFor(i)),
+      borderWidth: 0
+    }
+  ]
+}))
+
+const totalsData = computed(() => ({
+  labels: data.value?.bucketLabels ?? [],
+  datasets: [
+    {
+      label: 'Ventes',
+      data: data.value?.totals ?? [],
+      backgroundColor: '#16a34a',
+      borderRadius: 6
+    }
+  ]
+}))
+
+const stackedData = computed(() => ({
+  labels: data.value?.bucketLabels ?? [],
+  datasets:
+    data.value?.stackedByCategory.map((series, i) => ({
+      label: series.name,
+      data: series.values,
+      backgroundColor: colorFor(i),
+      borderRadius: 4,
+      stack: 'sales'
+    })) ?? []
+}))
+
+const barOptions = {
+  responsive: true,
+  maintainAspectRatio: false,
+  scales: { y: { beginAtZero: true } },
+  plugins: { legend: { display: false } }
+}
+
+const stackedOptions = {
+  responsive: true,
+  maintainAspectRatio: false,
+  scales: { x: { stacked: true }, y: { stacked: true, beginAtZero: true } },
+  plugins: { legend: { position: 'bottom' as const } }
+}
+
+const pieOptions = {
+  responsive: true,
+  maintainAspectRatio: false,
+  plugins: { legend: { position: 'bottom' as const } }
+}
+
+const hasData = computed(() => (data.value?.totals ?? []).some((v) => v > 0))
+</script>
+
+<template>
+  <UCard>
+    <template #header>
+      <div class="flex items-center justify-between gap-3">
+        <div>
+          <h2 class="font-semibold">Analyse des ventes</h2>
+          <p class="text-sm text-muted">{{ range === '7d' ? '7 derniers jours' : '5 dernières semaines' }}</p>
+        </div>
+        <div class="flex items-center gap-2">
+          <UTabs
+            v-model="range"
+            :items="[
+              { label: '7 jours', value: '7d' },
+              { label: '5 semaines', value: '5w' }
+            ]"
+            size="sm"
+          />
+          <UButton
+            icon="i-lucide-refresh-cw"
+            variant="ghost"
+            color="neutral"
+            :loading="pending"
+            aria-label="Rafraîchir"
+            @click="refresh()"
+          />
+        </div>
+      </div>
+    </template>
+
+    <div v-if="!hasData" class="py-12 text-center text-sm text-muted">
+      Aucune vente sur la période sélectionnée.
+    </div>
+
+    <div v-else class="grid gap-6 lg:grid-cols-3">
+      <div class="lg:col-span-1">
+        <h3 class="text-sm font-medium mb-2">Répartition par catégorie</h3>
+        <div class="h-64">
+          <Doughnut :data="pieData" :options="pieOptions" />
+        </div>
+      </div>
+      <div class="lg:col-span-2">
+        <h3 class="text-sm font-medium mb-2">Ventes par période</h3>
+        <div class="h-64">
+          <Bar :data="totalsData" :options="barOptions" />
+        </div>
+      </div>
+      <div class="lg:col-span-3">
+        <h3 class="text-sm font-medium mb-2">Décomposition par catégorie</h3>
+        <div class="h-72">
+          <Bar :data="stackedData" :options="stackedOptions" />
+        </div>
+      </div>
+    </div>
+  </UCard>
+</template>

--- a/apps/backoffice/app/pages/index.vue
+++ b/apps/backoffice/app/pages/index.vue
@@ -114,6 +114,15 @@ const statusColor: Record<string, 'primary' | 'success' | 'warning' | 'error' | 
         </UCard>
       </section>
 
+      <ClientOnly>
+        <SalesCharts />
+        <template #fallback>
+          <UCard>
+            <USkeleton class="h-64" />
+          </UCard>
+        </template>
+      </ClientOnly>
+
       <section class="grid gap-4 lg:grid-cols-3">
         <UCard class="lg:col-span-2">
           <template #header>

--- a/apps/backoffice/package.json
+++ b/apps/backoffice/package.json
@@ -14,8 +14,10 @@
     "@iconify-json/lucide": "^1.2.90",
     "@iconify-json/simple-icons": "^1.2.70",
     "@nuxt/ui": "^4.4.0",
+    "chart.js": "^4.5.1",
     "nuxt": "^4.3.1",
-    "tailwindcss": "^4.1.18"
+    "tailwindcss": "^4.1.18",
+    "vue-chartjs": "^5.3.3"
   },
   "devDependencies": {
     "@nuxt/eslint": "^1.15.1",


### PR DESCRIPTION
Closes #26.

Adds GET /admin/dashboard/sales returning sales aggregates over a 7-day or 5-week window — category distribution, total per bucket, and stacked-by-category series.

Backoffice renders the analytics card on the dashboard with chart.js + vue-chartjs: a doughnut for category share, a histogram for daily/weekly totals, and a stacked bar for per-category decomposition. A 7d/5w tab toggles the window and the request refetches via useAsyncData watching the range. Charts are rendered inside ClientOnly to keep SSR simple.