### PR TITLE
feat(backoffice): products management table and crud pages

### DIFF
--- a/apps/api/app/controllers/products_controller.ts
+++ b/apps/api/app/controllers/products_controller.ts
@@ -15,6 +15,11 @@ export default class ProductsController {
     return listProducts(query)
   }
 
+  async adminIndex({ request }: HttpContext) {
+    const query = await listProductsValidator.validate(request.qs())
+    return listProducts({ ...query, status: query.status ?? 'all' })
+  }
+
   async show({ params }: HttpContext) {
     return Product.query().where('slug', params.slug).preload('category').firstOrFail()
   }

--- a/apps/api/app/models/product.ts
+++ b/apps/api/app/models/product.ts
@@ -19,6 +19,11 @@ export default class Product extends BaseModel {
   @column()
   declare price: number
 
+  @column({
+    consume: (value: string | number | null) => (value === null ? 0 : Number(value)),
+  })
+  declare vatRate: number
+
   @column()
   declare stock: number
 

--- a/apps/api/app/services/product_search.ts
+++ b/apps/api/app/services/product_search.ts
@@ -1,8 +1,9 @@
 import Product from '#models/product'
 import type { ModelQueryBuilderContract } from '@adonisjs/lucid/types/model'
 
-export type SortKey = 'priority' | 'price' | 'date' | 'stock' | 'relevance'
+export type SortKey = 'priority' | 'price' | 'date' | 'stock' | 'relevance' | 'name'
 export type SortOrder = 'asc' | 'desc'
+export type StatusFilter = 'active' | 'inactive' | 'all'
 
 export interface ProductListQuery {
   q?: string
@@ -14,6 +15,8 @@ export interface ProductListQuery {
   order?: SortOrder
   page?: number
   perPage?: number
+  status?: StatusFilter
+  includeInactive?: boolean
 }
 
 const DEFAULT_PAGE = 1
@@ -43,7 +46,9 @@ function applyFilters(
   builder: ModelQueryBuilderContract<typeof Product>,
   query: ProductListQuery
 ) {
-  builder.where('isActive', true)
+  if (query.status === 'active') builder.where('isActive', true)
+  else if (query.status === 'inactive') builder.where('isActive', false)
+  else if (query.status !== 'all' && !query.includeInactive) builder.where('isActive', true)
 
   if (query.q) applyFuzzyTextFilter(builder, query.q)
   if (query.categoryId) builder.where('categoryId', query.categoryId)
@@ -92,6 +97,9 @@ function applySort(
       return
     case 'stock':
       builder.orderBy('stock', order)
+      return
+    case 'name':
+      builder.orderBy('name', order)
       return
     case 'priority':
     default:

--- a/apps/api/app/validators/product.ts
+++ b/apps/api/app/validators/product.ts
@@ -7,12 +7,15 @@ const slug = vine
   .maxLength(160)
   .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/)
 
+const vatRate = vine.number().min(0).max(50)
+
 export const createProductValidator = vine.compile(
   vine.object({
     name: vine.string().trim().minLength(2).maxLength(255),
     slug: slug.clone().unique({ table: 'products', column: 'slug' }),
     description: vine.string().trim().maxLength(8000).optional(),
     price: vine.number().positive(),
+    vatRate: vatRate.clone().optional(),
     stock: vine.number().withoutDecimals().min(0).optional(),
     categoryId: vine.number().positive().optional(),
     isActive: vine.boolean().optional(),
@@ -36,6 +39,7 @@ export const updateProductValidator = vine.withMetaData<{ productId: number }>()
       .optional(),
     description: vine.string().trim().maxLength(8000).nullable().optional(),
     price: vine.number().positive().optional(),
+    vatRate: vatRate.clone().optional(),
     stock: vine.number().withoutDecimals().min(0).optional(),
     categoryId: vine.number().positive().nullable().optional(),
     isActive: vine.boolean().optional(),
@@ -50,9 +54,10 @@ export const listProductsValidator = vine.compile(
     minPrice: vine.number().min(0).optional(),
     maxPrice: vine.number().min(0).optional(),
     inStockOnly: vine.boolean().optional(),
-    sort: vine.enum(['priority', 'price', 'date', 'stock', 'relevance'] as const).optional(),
+    sort: vine.enum(['priority', 'price', 'date', 'stock', 'relevance', 'name'] as const).optional(),
     order: vine.enum(['asc', 'desc'] as const).optional(),
     page: vine.number().withoutDecimals().min(1).optional(),
     perPage: vine.number().withoutDecimals().min(1).max(100).optional(),
+    status: vine.enum(['active', 'inactive', 'all'] as const).optional(),
   })
 )

--- a/apps/api/database/migrations/1773600000001_alter_products_add_vat_rate.ts
+++ b/apps/api/database/migrations/1773600000001_alter_products_add_vat_rate.ts
@@ -1,0 +1,17 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'products'
+
+  async up() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.decimal('vat_rate', 5, 2).notNullable().defaultTo(20.0)
+    })
+  }
+
+  async down() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.dropColumn('vat_rate')
+    })
+  }
+}

--- a/apps/api/start/routes.ts
+++ b/apps/api/start/routes.ts
@@ -126,6 +126,7 @@ router.get('/images/:id', [ProductImagesController, 'show'])
 
 router
   .group(() => {
+    router.get('/', [ProductsController, 'adminIndex'])
     router.post('/', [ProductsController, 'store'])
     router.patch(':id', [ProductsController, 'update'])
     router.delete(':id', [ProductsController, 'destroy'])

--- a/apps/backoffice/app/components/ProductForm.vue
+++ b/apps/backoffice/app/components/ProductForm.vue
@@ -1,0 +1,169 @@
+<script setup lang="ts">
+import type { AdminCategory, AdminProduct } from '~/composables/useApiTypes'
+
+interface Props {
+  product?: AdminProduct | null
+  categories: AdminCategory[]
+}
+
+const props = defineProps<Props>()
+const emit = defineEmits<{ saved: [AdminProduct] }>()
+
+const api = useApi()
+const router = useRouter()
+const toast = useToast()
+
+interface FormState {
+  name: string
+  slug: string
+  description: string
+  price: number
+  vatRate: number
+  stock: number
+  categoryId: number | null
+  isActive: boolean
+  sortPriority: number
+}
+
+const state = reactive<FormState>({
+  name: props.product?.name ?? '',
+  slug: props.product?.slug ?? '',
+  description: props.product?.description ?? '',
+  price: props.product?.price !== undefined ? Number(props.product.price) : 0,
+  vatRate: props.product?.vatRate ?? 20,
+  stock: props.product?.stock ?? 0,
+  categoryId: props.product?.categoryId ?? null,
+  isActive: props.product?.isActive ?? false,
+  sortPriority: props.product?.sortPriority ?? 0
+})
+
+const submitting = ref(false)
+
+const ttc = computed(() => {
+  const ht = Number(state.price) || 0
+  return ht + (ht * Number(state.vatRate)) / 100
+})
+
+const categoryItems = computed(() => [
+  { label: 'Sans catégorie', value: null as number | null },
+  ...props.categories.map((c) => ({ label: c.name, value: c.id }))
+])
+
+const vatItems = [
+  { label: '20 %', value: 20 },
+  { label: '10 %', value: 10 },
+  { label: '5,5 %', value: 5.5 },
+  { label: '0 %', value: 0 }
+]
+
+function slugify(value: string) {
+  return value
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '')
+}
+
+watch(
+  () => state.name,
+  (name) => {
+    if (!props.product && (!state.slug || state.slug === slugify(state.name.slice(0, -1)))) {
+      state.slug = slugify(name)
+    }
+  }
+)
+
+async function submit() {
+  if (submitting.value) return
+  submitting.value = true
+  try {
+    const body = {
+      name: state.name,
+      slug: state.slug,
+      description: state.description || undefined,
+      price: state.price,
+      vatRate: state.vatRate,
+      stock: state.stock,
+      categoryId: state.categoryId ?? null,
+      isActive: state.isActive,
+      sortPriority: state.sortPriority
+    }
+    if (props.product) {
+      const updated = await api<AdminProduct>(`/admin/products/${props.product.id}`, {
+        method: 'PATCH',
+        body
+      })
+      toast.add({ color: 'success', title: 'Produit mis à jour.' })
+      emit('saved', updated)
+    } else {
+      const created = await api<AdminProduct>('/admin/products', { method: 'POST', body })
+      toast.add({ color: 'success', title: 'Produit créé.' })
+      router.replace(`/products/${created.id}`)
+    }
+  } catch (err) {
+    toast.add({ color: 'error', title: extractMessage(err, 'Erreur lors de l\'enregistrement.') })
+  } finally {
+    submitting.value = false
+  }
+}
+
+function extractMessage(err: unknown, fallback: string) {
+  if (err && typeof err === 'object' && 'data' in err) {
+    const data = (err as { data?: { message?: string, errors?: Array<{ message: string }> } }).data
+    if (data?.errors?.[0]?.message) return data.errors[0].message
+    if (data?.message) return data.message
+  }
+  return fallback
+}
+</script>
+
+<template>
+  <UForm :state="state" class="space-y-6" @submit.prevent="submit">
+    <div class="grid gap-4 md:grid-cols-2">
+      <UFormField label="Nom" required>
+        <UInput v-model="state.name" class="w-full" />
+      </UFormField>
+      <UFormField label="Slug" required>
+        <UInput v-model="state.slug" class="w-full" />
+      </UFormField>
+    </div>
+
+    <UFormField label="Description">
+      <UTextarea v-model="state.description" :rows="4" class="w-full" />
+    </UFormField>
+
+    <div class="grid gap-4 md:grid-cols-3">
+      <UFormField label="Prix HT" required>
+        <UInput v-model.number="state.price" type="number" step="0.01" min="0" class="w-full" />
+      </UFormField>
+      <UFormField label="TVA">
+        <USelect v-model="state.vatRate" :items="vatItems" class="w-full" />
+      </UFormField>
+      <UFormField label="Prix TTC (calculé)">
+        <UInput :value="ttc.toFixed(2)" disabled class="w-full" />
+      </UFormField>
+    </div>
+
+    <div class="grid gap-4 md:grid-cols-3">
+      <UFormField label="Stock">
+        <UInput v-model.number="state.stock" type="number" min="0" class="w-full" />
+      </UFormField>
+      <UFormField label="Catégorie">
+        <USelect v-model="state.categoryId" :items="categoryItems" class="w-full" />
+      </UFormField>
+      <UFormField label="Priorité de tri">
+        <UInput v-model.number="state.sortPriority" type="number" min="0" class="w-full" />
+      </UFormField>
+    </div>
+
+    <UFormField label="Statut">
+      <USwitch v-model="state.isActive" :label="state.isActive ? 'Publié' : 'Brouillon'" />
+    </UFormField>
+
+    <div class="flex gap-2 justify-end">
+      <UButton type="button" variant="ghost" color="neutral" label="Annuler" @click="router.push('/products')" />
+      <UButton type="submit" :loading="submitting" :label="props.product ? 'Enregistrer' : 'Créer le produit'" />
+    </div>
+  </UForm>
+</template>

--- a/apps/backoffice/app/composables/useApiTypes.ts
+++ b/apps/backoffice/app/composables/useApiTypes.ts
@@ -1,0 +1,38 @@
+export interface Paginated<T> {
+  meta: {
+    total: number
+    perPage: number
+    currentPage: number
+    lastPage: number
+    firstPage: number
+    firstPageUrl: string
+    lastPageUrl: string
+    nextPageUrl: string | null
+    previousPageUrl: string | null
+  }
+  data: T[]
+}
+
+export interface AdminCategory {
+  id: number
+  name: string
+  slug: string
+  parentId: number | null
+  position: number
+}
+
+export interface AdminProduct {
+  id: number
+  name: string
+  slug: string
+  description: string | null
+  price: string | number
+  vatRate: number
+  stock: number
+  categoryId: number | null
+  category: AdminCategory | null
+  isActive: boolean
+  sortPriority: number
+  createdAt: string
+  updatedAt: string | null
+}

--- a/apps/backoffice/app/pages/products/[id].vue
+++ b/apps/backoffice/app/pages/products/[id].vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+import type { AdminCategory, AdminProduct, Paginated } from '~/composables/useApiTypes'
+
+const route = useRoute()
+const router = useRouter()
+const api = useApi()
+const toast = useToast()
+const id = Number(route.params.id)
+
+const { data: categories } = await useAsyncData<AdminCategory[]>('admin-categories', () =>
+  api<AdminCategory[]>('/categories')
+)
+
+const { data: product, refresh } = await useAsyncData<AdminProduct | null>(`admin-product-${id}`, async () => {
+  const list = await api<Paginated<AdminProduct>>('/admin/products', {
+    params: { perPage: 100, status: 'all' }
+  })
+  return list.data.find((p) => p.id === id) ?? null
+})
+
+if (!product.value) {
+  throw createError({ statusCode: 404, statusMessage: 'Produit introuvable' })
+}
+
+async function destroy() {
+  if (!product.value) return
+  if (!confirm(`Supprimer le produit “${product.value.name}” ?`)) return
+  await api(`/admin/products/${product.value.id}`, { method: 'DELETE' })
+  toast.add({ color: 'success', title: 'Produit supprimé.' })
+  router.push('/products')
+}
+</script>
+
+<template>
+  <UDashboardNavbar :title="product?.name ?? 'Produit'">
+    <template #left>
+      <UButton to="/products" icon="i-lucide-arrow-left" variant="ghost" color="neutral" label="Retour" />
+    </template>
+    <template #right>
+      <UButton color="error" variant="soft" icon="i-lucide-trash-2" label="Supprimer" @click="destroy" />
+    </template>
+  </UDashboardNavbar>
+  <UDashboardPanelContent class="p-4 sm:p-6">
+    <UCard v-if="product">
+      <ProductForm :product="product" :categories="categories ?? []" @saved="refresh()" />
+    </UCard>
+  </UDashboardPanelContent>
+</template>

--- a/apps/backoffice/app/pages/products/index.vue
+++ b/apps/backoffice/app/pages/products/index.vue
@@ -1,0 +1,226 @@
+<script setup lang="ts">
+import type { AdminCategory, AdminProduct, Paginated } from '~/composables/useApiTypes'
+
+const api = useApi()
+const { currency, dateTime } = useFormat()
+
+const search = ref('')
+const status = ref<'all' | 'active' | 'inactive'>('all')
+const categoryId = ref<number | null>(null)
+const page = ref(1)
+const perPage = ref(25)
+
+const debouncedSearch = ref('')
+let debounceTimer: ReturnType<typeof setTimeout> | undefined
+watch(search, (value) => {
+  if (debounceTimer) clearTimeout(debounceTimer)
+  debounceTimer = setTimeout(() => {
+    debouncedSearch.value = value
+  }, 300)
+})
+
+const { data: categories } = await useAsyncData<AdminCategory[]>('admin-categories', () =>
+  api<AdminCategory[]>('/categories')
+)
+
+const queryParams = computed(() => {
+  const params: Record<string, string | number> = {
+    page: page.value,
+    perPage: perPage.value,
+    status: status.value,
+    sort: 'date',
+    order: 'desc'
+  }
+  if (debouncedSearch.value) params.q = debouncedSearch.value
+  if (categoryId.value) params.categoryId = categoryId.value
+  return params
+})
+
+const { data, pending, refresh } = await useAsyncData<Paginated<AdminProduct>>(
+  'admin-products',
+  () => api<Paginated<AdminProduct>>('/admin/products', { params: queryParams.value }),
+  { watch: [queryParams] }
+)
+
+watch([debouncedSearch, status, categoryId, perPage], () => {
+  page.value = 1
+})
+
+function ttc(price: number | string, vatRate: number) {
+  const ht = Number(price)
+  return ht + (ht * vatRate) / 100
+}
+
+const categoryItems = computed(() => [
+  { label: 'Toutes', value: null as number | null },
+  ...((categories.value ?? []).map((c) => ({ label: c.name, value: c.id })))
+])
+
+const statusItems = [
+  { label: 'Tous', value: 'all' as const },
+  { label: 'Publié', value: 'active' as const },
+  { label: 'Brouillon', value: 'inactive' as const }
+]
+
+const perPageItems = [
+  { label: '10 / page', value: 10 },
+  { label: '25 / page', value: 25 },
+  { label: '50 / page', value: 50 }
+]
+
+async function destroy(product: AdminProduct) {
+  if (!confirm(`Supprimer le produit “${product.name}” ?`)) return
+  await api(`/admin/products/${product.id}`, { method: 'DELETE' })
+  refresh()
+}
+
+function exportCsv() {
+  const rows = data.value?.data ?? []
+  const header = ['id', 'nom', 'categorie', 'prix_ht', 'tva', 'prix_ttc', 'stock', 'statut', 'cree_le']
+  const lines = rows.map((p) => [
+    p.id,
+    quote(p.name),
+    quote(p.category?.name ?? ''),
+    Number(p.price).toFixed(2),
+    p.vatRate,
+    ttc(p.price, p.vatRate).toFixed(2),
+    p.stock,
+    p.isActive ? 'publie' : 'brouillon',
+    p.createdAt
+  ].join(','))
+  const csv = [header.join(','), ...lines].join('\n')
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = `produits-${new Date().toISOString().slice(0, 10)}.csv`
+  a.click()
+  URL.revokeObjectURL(url)
+}
+
+function quote(value: string) {
+  return `"${value.replace(/"/g, '""')}"`
+}
+</script>
+
+<template>
+  <UDashboardNavbar title="Produits">
+    <template #right>
+      <UButton to="/products/new" icon="i-lucide-plus" label="Nouveau produit" />
+    </template>
+  </UDashboardNavbar>
+
+  <UDashboardPanelContent class="p-4 sm:p-6">
+    <UCard>
+      <template #header>
+        <div class="flex flex-wrap items-center gap-3">
+          <UInput
+            v-model="search"
+            icon="i-lucide-search"
+            placeholder="Rechercher..."
+            class="w-64"
+          />
+          <USelect v-model="status" :items="statusItems" class="w-40" />
+          <USelect v-model="categoryId" :items="categoryItems" class="w-48" />
+          <USelect v-model="perPage" :items="perPageItems" class="w-32" />
+          <span class="ml-auto flex gap-2">
+            <UButton
+              icon="i-lucide-download"
+              variant="ghost"
+              color="neutral"
+              label="CSV"
+              :disabled="!data?.data?.length"
+              @click="exportCsv"
+            />
+            <UButton
+              icon="i-lucide-refresh-cw"
+              variant="ghost"
+              color="neutral"
+              :loading="pending"
+              aria-label="Rafraîchir"
+              @click="refresh()"
+            />
+          </span>
+        </div>
+      </template>
+
+      <div v-if="pending && !data" class="py-12 text-center text-sm text-muted">Chargement...</div>
+      <div v-else-if="!data?.data?.length" class="py-12 text-center text-sm text-muted">
+        Aucun produit ne correspond à ces filtres.
+      </div>
+      <div v-else class="overflow-x-auto">
+        <table class="min-w-full text-sm">
+          <thead class="text-left text-muted uppercase text-xs">
+            <tr>
+              <th class="px-3 py-2">Nom</th>
+              <th class="px-3 py-2">Catégorie</th>
+              <th class="px-3 py-2 text-right">HT</th>
+              <th class="px-3 py-2 text-right">TVA</th>
+              <th class="px-3 py-2 text-right">TTC</th>
+              <th class="px-3 py-2 text-right">Stock</th>
+              <th class="px-3 py-2">Statut</th>
+              <th class="px-3 py-2">Créé le</th>
+              <th class="px-3 py-2 text-right">Actions</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-default">
+            <tr v-for="product in data.data" :key="product.id">
+              <td class="px-3 py-3">
+                <div class="font-medium">{{ product.name }}</div>
+                <div v-if="product.description" class="text-xs text-muted line-clamp-1 max-w-md">
+                  {{ product.description }}
+                </div>
+              </td>
+              <td class="px-3 py-3">{{ product.category?.name || '—' }}</td>
+              <td class="px-3 py-3 text-right">{{ currency(product.price) }}</td>
+              <td class="px-3 py-3 text-right">{{ product.vatRate }} %</td>
+              <td class="px-3 py-3 text-right font-medium">{{ currency(ttc(product.price, product.vatRate)) }}</td>
+              <td class="px-3 py-3 text-right">
+                <span :class="product.stock <= 0 ? 'text-error font-medium' : ''">{{ product.stock }}</span>
+              </td>
+              <td class="px-3 py-3">
+                <UBadge :color="product.isActive ? 'success' : 'warning'" variant="subtle">
+                  {{ product.isActive ? 'Publié' : 'Brouillon' }}
+                </UBadge>
+              </td>
+              <td class="px-3 py-3 text-muted text-xs">{{ dateTime(product.createdAt) }}</td>
+              <td class="px-3 py-3 text-right">
+                <div class="flex justify-end gap-1">
+                  <UButton
+                    :to="`/products/${product.id}`"
+                    icon="i-lucide-pencil"
+                    variant="ghost"
+                    color="neutral"
+                    size="sm"
+                    aria-label="Éditer"
+                  />
+                  <UButton
+                    icon="i-lucide-trash-2"
+                    variant="ghost"
+                    color="error"
+                    size="sm"
+                    aria-label="Supprimer"
+                    @click="destroy(product)"
+                  />
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <template v-if="data && data.meta.lastPage > 1" #footer>
+        <div class="flex items-center justify-between">
+          <p class="text-sm text-muted">
+            {{ data.meta.total }} produit(s) — page {{ data.meta.currentPage }} / {{ data.meta.lastPage }}
+          </p>
+          <UPagination
+            v-model:page="page"
+            :items-per-page="perPage"
+            :total="data.meta.total"
+          />
+        </div>
+      </template>
+    </UCard>
+  </UDashboardPanelContent>
+</template>

--- a/apps/backoffice/app/pages/products/new.vue
+++ b/apps/backoffice/app/pages/products/new.vue
@@ -1,0 +1,21 @@
+<script setup lang="ts">
+import type { AdminCategory } from '~/composables/useApiTypes'
+
+const api = useApi()
+const { data: categories } = await useAsyncData<AdminCategory[]>('admin-categories', () =>
+  api<AdminCategory[]>('/categories')
+)
+</script>
+
+<template>
+  <UDashboardNavbar title="Nouveau produit">
+    <template #left>
+      <UButton to="/products" icon="i-lucide-arrow-left" variant="ghost" color="neutral" label="Retour" />
+    </template>
+  </UDashboardNavbar>
+  <UDashboardPanelContent class="p-4 sm:p-6">
+    <UCard>
+      <ProductForm :categories="categories ?? []" />
+    </UCard>
+  </UDashboardPanelContent>
+</template>


### PR DESCRIPTION
Closes #27, closes #28.

Adds vat_rate on products (default 20%), an admin product list endpoint that includes drafts and supports a status filter, and a name sort option. Validators accept the new vatRate field.

Backoffice ships /products with a search box, status and category filters, configurable page size (10/25/50), CSV export and a refresh button. Each row shows name, category, price HT, TVA, calculated TTC, stock (red when 0), status badge and creation date with edit/delete quick actions. /products/new and /products/:id reuse a shared ProductForm with auto-slugify, live TTC computation and a publish toggle.