### PR TITLE
feat(backoffice): categories management

### DIFF
--- a/apps/api/app/controllers/admin_categories_controller.ts
+++ b/apps/api/app/controllers/admin_categories_controller.ts
@@ -1,0 +1,44 @@
+import type { HttpContext } from '@adonisjs/core/http'
+import db from '@adonisjs/lucid/services/db'
+import Category from '#models/category'
+import {
+  bulkSetCategoryStatusValidator,
+  reorderCategoriesValidator,
+} from '#validators/category'
+
+export default class AdminCategoriesController {
+  async index() {
+    const categories = await Category.query().orderBy('position', 'asc').orderBy('name', 'asc')
+    const counts = await db
+      .from('products')
+      .select('category_id')
+      .count('* as total')
+      .groupBy('category_id')
+
+    const countByCategory = new Map<number, number>()
+    for (const row of counts) {
+      if (row.category_id !== null) countByCategory.set(Number(row.category_id), Number(row.total))
+    }
+
+    return categories.map((category) => ({
+      ...category.serialize(),
+      productCount: countByCategory.get(category.id) ?? 0,
+    }))
+  }
+
+  async reorder({ request, response }: HttpContext) {
+    const { items } = await request.validateUsing(reorderCategoriesValidator)
+    await db.transaction(async (trx) => {
+      for (const item of items) {
+        await trx.from('categories').where('id', item.id).update({ position: item.position })
+      }
+    })
+    return response.noContent()
+  }
+
+  async bulkStatus({ request, response }: HttpContext) {
+    const { ids, isActive } = await request.validateUsing(bulkSetCategoryStatusValidator)
+    await db.from('categories').whereIn('id', ids).update({ is_active: isActive })
+    return response.noContent()
+  }
+}

--- a/apps/api/app/models/category.ts
+++ b/apps/api/app/models/category.ts
@@ -25,6 +25,9 @@ export default class Category extends BaseModel {
   @column()
   declare position: number
 
+  @column()
+  declare isActive: boolean
+
   @column.dateTime({ autoCreate: true })
   declare createdAt: DateTime
 

--- a/apps/api/app/validators/category.ts
+++ b/apps/api/app/validators/category.ts
@@ -15,6 +15,7 @@ export const createCategoryValidator = vine.compile(
     parentId: vine.number().positive().optional(),
     imagePath: vine.string().trim().maxLength(255).optional(),
     position: vine.number().withoutDecimals().min(0).optional(),
+    isActive: vine.boolean().optional(),
   })
 )
 
@@ -36,5 +37,27 @@ export const updateCategoryValidator = vine.withMetaData<{ categoryId: number }>
     parentId: vine.number().positive().nullable().optional(),
     imagePath: vine.string().trim().maxLength(255).nullable().optional(),
     position: vine.number().withoutDecimals().min(0).optional(),
+    isActive: vine.boolean().optional(),
+  })
+)
+
+export const reorderCategoriesValidator = vine.compile(
+  vine.object({
+    items: vine
+      .array(
+        vine.object({
+          id: vine.number().positive(),
+          position: vine.number().withoutDecimals().min(0),
+        })
+      )
+      .minLength(1)
+      .maxLength(500),
+  })
+)
+
+export const bulkSetCategoryStatusValidator = vine.compile(
+  vine.object({
+    ids: vine.array(vine.number().positive()).minLength(1).maxLength(200),
+    isActive: vine.boolean(),
   })
 )

--- a/apps/api/database/migrations/1773700000001_alter_categories_add_is_active.ts
+++ b/apps/api/database/migrations/1773700000001_alter_categories_add_is_active.ts
@@ -1,0 +1,17 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'categories'
+
+  async up() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.boolean('is_active').notNullable().defaultTo(true)
+    })
+  }
+
+  async down() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.dropColumn('is_active')
+    })
+  }
+}

--- a/apps/api/start/routes.ts
+++ b/apps/api/start/routes.ts
@@ -12,6 +12,7 @@ const OrdersController = () => import('#controllers/orders_controller')
 const CheckoutController = () => import('#controllers/checkout_controller')
 const ProductsController = () => import('#controllers/products_controller')
 const CategoriesController = () => import('#controllers/categories_controller')
+const AdminCategoriesController = () => import('#controllers/admin_categories_controller')
 const ProductImagesController = () => import('#controllers/product_images_controller')
 const SiteConfigController = () => import('#controllers/site_config_controller')
 
@@ -106,7 +107,10 @@ router
 
 router
   .group(() => {
+    router.get('/', [AdminCategoriesController, 'index'])
     router.post('/', [CategoriesController, 'store'])
+    router.post('reorder', [AdminCategoriesController, 'reorder'])
+    router.post('bulk-status', [AdminCategoriesController, 'bulkStatus'])
     router.patch(':id', [CategoriesController, 'update'])
     router.delete(':id', [CategoriesController, 'destroy'])
   })

--- a/apps/backoffice/app/components/CategoryForm.vue
+++ b/apps/backoffice/app/components/CategoryForm.vue
@@ -1,0 +1,118 @@
+<script setup lang="ts">
+import type { AdminCategory } from '~/composables/useApiTypes'
+
+interface Props {
+  category?: AdminCategory | null
+  parents: AdminCategory[]
+}
+
+const props = defineProps<Props>()
+const emit = defineEmits<{ saved: [AdminCategory] }>()
+
+const api = useApi()
+const router = useRouter()
+const toast = useToast()
+
+const state = reactive({
+  name: props.category?.name ?? '',
+  slug: props.category?.slug ?? '',
+  description: props.category?.description ?? '',
+  parentId: props.category?.parentId ?? null as number | null,
+  imagePath: props.category?.imagePath ?? '',
+  position: props.category?.position ?? 0,
+  isActive: props.category?.isActive ?? true
+})
+const submitting = ref(false)
+
+const parentItems = computed(() => [
+  { label: 'Aucune (racine)', value: null as number | null },
+  ...props.parents
+    .filter((c) => !props.category || c.id !== props.category.id)
+    .map((c) => ({ label: c.name, value: c.id }))
+])
+
+function slugify(value: string) {
+  return value.toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g, '').replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '')
+}
+
+watch(
+  () => state.name,
+  (name) => {
+    if (!props.category && (!state.slug || state.slug === slugify(state.name.slice(0, -1)))) {
+      state.slug = slugify(name)
+    }
+  }
+)
+
+async function submit() {
+  if (submitting.value) return
+  submitting.value = true
+  try {
+    const body = {
+      name: state.name,
+      slug: state.slug,
+      description: state.description || undefined,
+      parentId: state.parentId ?? null,
+      imagePath: state.imagePath || null,
+      position: state.position,
+      isActive: state.isActive
+    }
+    if (props.category) {
+      const updated = await api<AdminCategory>(`/admin/categories/${props.category.id}`, { method: 'PATCH', body })
+      toast.add({ color: 'success', title: 'Catégorie mise à jour.' })
+      emit('saved', updated)
+    } else {
+      const created = await api<AdminCategory>('/admin/categories', { method: 'POST', body })
+      toast.add({ color: 'success', title: 'Catégorie créée.' })
+      router.replace(`/categories/${created.id}`)
+    }
+  } catch (err) {
+    toast.add({ color: 'error', title: extractMessage(err, 'Erreur lors de l\'enregistrement.') })
+  } finally {
+    submitting.value = false
+  }
+}
+
+function extractMessage(err: unknown, fallback: string) {
+  if (err && typeof err === 'object' && 'data' in err) {
+    const data = (err as { data?: { message?: string, errors?: Array<{ message: string }> } }).data
+    if (data?.errors?.[0]?.message) return data.errors[0].message
+    if (data?.message) return data.message
+  }
+  return fallback
+}
+</script>
+
+<template>
+  <UForm :state="state" class="space-y-6" @submit.prevent="submit">
+    <div class="grid gap-4 md:grid-cols-2">
+      <UFormField label="Nom" required>
+        <UInput v-model="state.name" class="w-full" />
+      </UFormField>
+      <UFormField label="Slug" required>
+        <UInput v-model="state.slug" class="w-full" />
+      </UFormField>
+    </div>
+    <UFormField label="Description">
+      <UTextarea v-model="state.description" :rows="3" class="w-full" />
+    </UFormField>
+    <div class="grid gap-4 md:grid-cols-3">
+      <UFormField label="Catégorie parente">
+        <USelect v-model="state.parentId" :items="parentItems" class="w-full" />
+      </UFormField>
+      <UFormField label="Position">
+        <UInput v-model.number="state.position" type="number" min="0" class="w-full" />
+      </UFormField>
+      <UFormField label="Image (chemin)">
+        <UInput v-model="state.imagePath" class="w-full" placeholder="/images/cat.jpg" />
+      </UFormField>
+    </div>
+    <UFormField label="Statut">
+      <USwitch v-model="state.isActive" :label="state.isActive ? 'Active' : 'Désactivée'" />
+    </UFormField>
+    <div class="flex gap-2 justify-end">
+      <UButton type="button" variant="ghost" color="neutral" label="Annuler" @click="router.push('/categories')" />
+      <UButton type="submit" :loading="submitting" :label="props.category ? 'Enregistrer' : 'Créer la catégorie'" />
+    </div>
+  </UForm>
+</template>

--- a/apps/backoffice/app/composables/useApiTypes.ts
+++ b/apps/backoffice/app/composables/useApiTypes.ts
@@ -17,8 +17,12 @@ export interface AdminCategory {
   id: number
   name: string
   slug: string
+  description: string | null
   parentId: number | null
+  imagePath: string | null
   position: number
+  isActive: boolean
+  productCount?: number
 }
 
 export interface AdminProduct {

--- a/apps/backoffice/app/pages/categories/[id].vue
+++ b/apps/backoffice/app/pages/categories/[id].vue
@@ -1,0 +1,43 @@
+<script setup lang="ts">
+import type { AdminCategory } from '~/composables/useApiTypes'
+
+const route = useRoute()
+const router = useRouter()
+const api = useApi()
+const toast = useToast()
+const id = Number(route.params.id)
+
+const { data: categories, refresh } = await useAsyncData<AdminCategory[]>('admin-categories-list', () =>
+  api<AdminCategory[]>('/admin/categories')
+)
+
+const category = computed(() => categories.value?.find((c) => c.id === id) ?? null)
+
+if (!category.value) {
+  throw createError({ statusCode: 404, statusMessage: 'Catégorie introuvable' })
+}
+
+async function destroy() {
+  if (!category.value) return
+  if (!confirm(`Supprimer la catégorie « ${category.value.name} » ?`)) return
+  await api(`/admin/categories/${category.value.id}`, { method: 'DELETE' })
+  toast.add({ color: 'success', title: 'Catégorie supprimée.' })
+  router.push('/categories')
+}
+</script>
+
+<template>
+  <UDashboardNavbar :title="category?.name ?? 'Catégorie'">
+    <template #left>
+      <UButton to="/categories" icon="i-lucide-arrow-left" variant="ghost" color="neutral" label="Retour" />
+    </template>
+    <template #right>
+      <UButton color="error" variant="soft" icon="i-lucide-trash-2" label="Supprimer" @click="destroy" />
+    </template>
+  </UDashboardNavbar>
+  <UDashboardPanelContent class="p-4 sm:p-6">
+    <UCard v-if="category">
+      <CategoryForm :category="category" :parents="categories ?? []" @saved="refresh()" />
+    </UCard>
+  </UDashboardPanelContent>
+</template>

--- a/apps/backoffice/app/pages/categories/index.vue
+++ b/apps/backoffice/app/pages/categories/index.vue
@@ -1,0 +1,191 @@
+<script setup lang="ts">
+import type { AdminCategory } from '~/composables/useApiTypes'
+
+const api = useApi()
+const toast = useToast()
+
+const { data, refresh, pending } = await useAsyncData<AdminCategory[]>('admin-categories-list', () =>
+  api<AdminCategory[]>('/admin/categories')
+)
+
+const selected = ref<Set<number>>(new Set())
+
+interface Node extends AdminCategory {
+  children: Node[]
+  depth: number
+}
+
+const tree = computed(() => buildTree(data.value ?? []))
+const flat = computed(() => flatten(tree.value))
+
+function buildTree(items: AdminCategory[]): Node[] {
+  const map = new Map<number, Node>()
+  items.forEach((c) => map.set(c.id, { ...c, children: [], depth: 0 }))
+  const roots: Node[] = []
+  for (const node of map.values()) {
+    if (node.parentId && map.has(node.parentId)) {
+      const parent = map.get(node.parentId)!
+      node.depth = parent.depth + 1
+      parent.children.push(node)
+    } else {
+      roots.push(node)
+    }
+  }
+  for (const node of map.values()) node.children.sort((a, b) => a.position - b.position)
+  roots.sort((a, b) => a.position - b.position)
+  return roots
+}
+
+function flatten(nodes: Node[], depth = 0, acc: Node[] = []): Node[] {
+  for (const node of nodes) {
+    acc.push({ ...node, depth })
+    flatten(node.children, depth + 1, acc)
+  }
+  return acc
+}
+
+function toggleSelect(id: number) {
+  const copy = new Set(selected.value)
+  if (copy.has(id)) copy.delete(id); else copy.add(id)
+  selected.value = copy
+}
+
+function clearSelection() { selected.value = new Set() }
+
+async function destroy(category: AdminCategory) {
+  if (!confirm(`Supprimer la catégorie « ${category.name} » ?`)) return
+  await api(`/admin/categories/${category.id}`, { method: 'DELETE' })
+  toast.add({ color: 'success', title: 'Catégorie supprimée.' })
+  refresh()
+}
+
+async function move(category: Node, direction: -1 | 1) {
+  const siblings = (category.parentId
+    ? data.value?.find((c) => c.id === category.parentId) && flat.value.filter((n) => n.parentId === category.parentId)
+    : flat.value.filter((n) => n.parentId === null)) || []
+  const sorted = [...siblings].sort((a, b) => a.position - b.position)
+  const idx = sorted.findIndex((c) => c.id === category.id)
+  const swapIdx = idx + direction
+  if (idx === -1 || swapIdx < 0 || swapIdx >= sorted.length) return
+  const a = sorted[idx]
+  const b = sorted[swapIdx]
+  if (!a || !b) return
+  const items = [
+    { id: a.id, position: b.position },
+    { id: b.id, position: a.position }
+  ]
+  await api('/admin/categories/reorder', { method: 'POST', body: { items } })
+  refresh()
+}
+
+async function bulkSetStatus(isActive: boolean) {
+  if (!selected.value.size) return
+  await api('/admin/categories/bulk-status', {
+    method: 'POST',
+    body: { ids: [...selected.value], isActive }
+  })
+  toast.add({ color: 'success', title: `${selected.value.size} catégorie(s) ${isActive ? 'activée(s)' : 'désactivée(s)'}.` })
+  clearSelection()
+  refresh()
+}
+</script>
+
+<template>
+  <UDashboardNavbar title="Catégories">
+    <template #right>
+      <UButton to="/categories/new" icon="i-lucide-plus" label="Nouvelle catégorie" />
+    </template>
+  </UDashboardNavbar>
+  <UDashboardPanelContent class="p-4 sm:p-6">
+    <UCard>
+      <template #header>
+        <div class="flex items-center justify-between gap-3">
+          <p class="text-sm text-muted">{{ data?.length ?? 0 }} catégorie(s)</p>
+          <div class="flex items-center gap-2">
+            <UButton
+              v-if="selected.size"
+              icon="i-lucide-eye"
+              color="primary"
+              variant="soft"
+              size="sm"
+              :label="`Activer (${selected.size})`"
+              @click="bulkSetStatus(true)"
+            />
+            <UButton
+              v-if="selected.size"
+              icon="i-lucide-eye-off"
+              color="warning"
+              variant="soft"
+              size="sm"
+              :label="`Désactiver (${selected.size})`"
+              @click="bulkSetStatus(false)"
+            />
+            <UButton
+              icon="i-lucide-refresh-cw"
+              variant="ghost"
+              color="neutral"
+              :loading="pending"
+              aria-label="Rafraîchir"
+              @click="refresh()"
+            />
+          </div>
+        </div>
+      </template>
+
+      <div v-if="!flat.length" class="py-12 text-center text-sm text-muted">
+        Aucune catégorie. Créez la première via le bouton en haut à droite.
+      </div>
+      <div v-else class="overflow-x-auto">
+        <table class="min-w-full text-sm">
+          <thead class="text-left text-muted uppercase text-xs">
+            <tr>
+              <th class="px-3 py-2 w-10"></th>
+              <th class="px-3 py-2">Nom</th>
+              <th class="px-3 py-2">Description</th>
+              <th class="px-3 py-2 text-right">Produits</th>
+              <th class="px-3 py-2 text-right">Position</th>
+              <th class="px-3 py-2">Statut</th>
+              <th class="px-3 py-2 text-right">Actions</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-default">
+            <tr v-for="category in flat" :key="category.id">
+              <td class="px-3 py-3">
+                <UCheckbox :model-value="selected.has(category.id)" @update:model-value="toggleSelect(category.id)" />
+              </td>
+              <td class="px-3 py-3">
+                <div class="flex items-center gap-2" :style="{ paddingLeft: `${category.depth * 16}px` }">
+                  <UIcon v-if="category.depth > 0" name="i-lucide-corner-down-right" class="text-muted size-4" />
+                  <span class="font-medium">{{ category.name }}</span>
+                  <span class="text-xs text-muted">/{{ category.slug }}</span>
+                </div>
+              </td>
+              <td class="px-3 py-3 text-muted text-xs max-w-md">
+                <span class="line-clamp-1">{{ category.description || '—' }}</span>
+              </td>
+              <td class="px-3 py-3 text-right">{{ category.productCount ?? 0 }}</td>
+              <td class="px-3 py-3 text-right">
+                <div class="inline-flex items-center gap-1">
+                  <UButton icon="i-lucide-arrow-up" size="xs" variant="ghost" color="neutral" aria-label="Monter" @click="move(category, -1)" />
+                  <span>{{ category.position }}</span>
+                  <UButton icon="i-lucide-arrow-down" size="xs" variant="ghost" color="neutral" aria-label="Descendre" @click="move(category, 1)" />
+                </div>
+              </td>
+              <td class="px-3 py-3">
+                <UBadge :color="category.isActive ? 'success' : 'warning'" variant="subtle">
+                  {{ category.isActive ? 'Active' : 'Désactivée' }}
+                </UBadge>
+              </td>
+              <td class="px-3 py-3 text-right">
+                <div class="flex justify-end gap-1">
+                  <UButton :to="`/categories/${category.id}`" icon="i-lucide-pencil" variant="ghost" color="neutral" size="sm" aria-label="Éditer" />
+                  <UButton icon="i-lucide-trash-2" variant="ghost" color="error" size="sm" aria-label="Supprimer" @click="destroy(category)" />
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </UCard>
+  </UDashboardPanelContent>
+</template>

--- a/apps/backoffice/app/pages/categories/new.vue
+++ b/apps/backoffice/app/pages/categories/new.vue
@@ -1,0 +1,21 @@
+<script setup lang="ts">
+import type { AdminCategory } from '~/composables/useApiTypes'
+
+const api = useApi()
+const { data: parents } = await useAsyncData<AdminCategory[]>('admin-categories-list', () =>
+  api<AdminCategory[]>('/admin/categories')
+)
+</script>
+
+<template>
+  <UDashboardNavbar title="Nouvelle catégorie">
+    <template #left>
+      <UButton to="/categories" icon="i-lucide-arrow-left" variant="ghost" color="neutral" label="Retour" />
+    </template>
+  </UDashboardNavbar>
+  <UDashboardPanelContent class="p-4 sm:p-6">
+    <UCard>
+      <CategoryForm :parents="parents ?? []" />
+    </UCard>
+  </UDashboardPanelContent>
+</template>


### PR DESCRIPTION
Closes #29.

API gets is_active on categories, an admin list endpoint that joins product counts, a reorder endpoint that swaps positions in a transaction, and a bulk-status endpoint for multi-select activate/deactivate.

Backoffice ships /categories as a hierarchical table (children indented under their parent) showing name, slug, description, product count, position with up/down arrows for reordering, status badge and edit/delete. A checkbox per row drives bulk activate/deactivate. /categories/new and /categories/:id share a CategoryForm with auto-slugify, parent selector that excludes self and a publish toggle.