### PR TITLE
feat(backoffice): users management

### DIFF
--- a/apps/api/app/controllers/admin_users_controller.ts
+++ b/apps/api/app/controllers/admin_users_controller.ts
@@ -1,0 +1,130 @@
+import type { HttpContext } from '@adonisjs/core/http'
+import { DateTime } from 'luxon'
+import db from '@adonisjs/lucid/services/db'
+import User from '#models/user'
+import PasswordReset from '#models/password_reset'
+import Address from '#models/address'
+import Order from '#models/order'
+import { listUsersValidator, updateUserAdminValidator } from '#validators/admin_users'
+import { createToken } from '#services/token_factory'
+import { sendPasswordReset } from '#services/account_mailer'
+
+const REVENUE_STATUSES = ['paid', 'processing', 'shipped', 'delivered']
+const RESET_TTL_HOURS = 24
+
+export default class AdminUsersController {
+  async index({ request }: HttpContext) {
+    const { q, status, page = 1, perPage = 25 } = await listUsersValidator.validate(request.qs())
+
+    const builder = User.query()
+
+    if (status === 'active') builder.where('isActive', true).whereNotNull('emailVerifiedAt')
+    else if (status === 'inactive') builder.where('isActive', false)
+    else if (status === 'pending') builder.where('isActive', true).whereNull('emailVerifiedAt')
+
+    if (q) {
+      builder.where((sub) => {
+        const pattern = `%${q}%`
+        sub.whereILike('email', pattern).orWhereILike('fullName', pattern)
+      })
+    }
+
+    builder.orderBy('createdAt', 'desc')
+
+    const result = await builder.paginate(page, perPage)
+    const ids = result.all().map((u) => u.id)
+    const stats = await loadOrderStats(ids)
+
+    return {
+      meta: result.getMeta(),
+      data: result.all().map((user) => ({
+        ...user.serialize(),
+        orderCount: stats.get(user.id)?.orderCount ?? 0,
+        totalRevenue: stats.get(user.id)?.totalRevenue ?? 0,
+        accountStatus: deriveStatus(user),
+      })),
+    }
+  }
+
+  async show({ params }: HttpContext) {
+    const user = await User.findOrFail(params.id)
+    const [addresses, orders, stats] = await Promise.all([
+      Address.query().where('userId', user.id).orderBy('isDefault', 'desc'),
+      Order.query().where('userId', user.id).orderBy('createdAt', 'desc').limit(10),
+      loadOrderStats([user.id]),
+    ])
+    const summary = stats.get(user.id) ?? { orderCount: 0, totalRevenue: 0 }
+    return {
+      user: { ...user.serialize(), accountStatus: deriveStatus(user) },
+      addresses,
+      orders,
+      orderCount: summary.orderCount,
+      totalRevenue: summary.totalRevenue,
+    }
+  }
+
+  async update({ params, request }: HttpContext) {
+    const user = await User.findOrFail(params.id)
+    const payload = await request.validateUsing(updateUserAdminValidator)
+    user.merge(payload)
+    await user.save()
+    return { user: { ...user.serialize(), accountStatus: deriveStatus(user) } }
+  }
+
+  async destroy({ params, response }: HttpContext) {
+    const user = await User.findOrFail(params.id)
+    if (user.role === 'admin') {
+      return response.unprocessableEntity({
+        message: 'Impossible de supprimer un compte administrateur.',
+      })
+    }
+    await user.delete()
+    return response.noContent()
+  }
+
+  async sendPasswordReset({ params, response }: HttpContext) {
+    const user = await User.findOrFail(params.id)
+    const { value, hash } = createToken()
+    await PasswordReset.create({
+      userId: user.id,
+      tokenHash: hash,
+      expiresAt: DateTime.now().plus({ hours: RESET_TTL_HOURS }),
+    })
+    await sendPasswordReset(user, value)
+    return response.accepted({ message: 'Email de réinitialisation envoyé.' })
+  }
+}
+
+interface OrderStats {
+  orderCount: number
+  totalRevenue: number
+}
+
+async function loadOrderStats(userIds: number[]): Promise<Map<number, OrderStats>> {
+  const map = new Map<number, OrderStats>()
+  if (!userIds.length) return map
+  const rows = await db
+    .from('orders')
+    .whereIn('user_id', userIds)
+    .groupBy('user_id')
+    .select('user_id')
+    .select(db.raw('COUNT(*)::int as order_count'))
+    .select(
+      db.raw(
+        'COALESCE(SUM(CASE WHEN status IN (?, ?, ?, ?) THEN total ELSE 0 END), 0)::numeric as total_revenue',
+        REVENUE_STATUSES
+      )
+    )
+  for (const row of rows) {
+    map.set(Number(row.user_id), {
+      orderCount: Number(row.order_count ?? 0),
+      totalRevenue: Number(row.total_revenue ?? 0),
+    })
+  }
+  return map
+}
+
+function deriveStatus(user: User): 'active' | 'inactive' | 'pending' {
+  if (!user.isActive) return 'inactive'
+  return user.emailVerifiedAt ? 'active' : 'pending'
+}

--- a/apps/api/app/validators/admin_users.ts
+++ b/apps/api/app/validators/admin_users.ts
@@ -1,0 +1,17 @@
+import vine from '@vinejs/vine'
+
+export const listUsersValidator = vine.compile(
+  vine.object({
+    q: vine.string().trim().minLength(1).maxLength(120).optional(),
+    status: vine.enum(['all', 'active', 'inactive', 'pending'] as const).optional(),
+    page: vine.number().withoutDecimals().min(1).optional(),
+    perPage: vine.number().withoutDecimals().min(1).max(100).optional(),
+  })
+)
+
+export const updateUserAdminValidator = vine.compile(
+  vine.object({
+    isActive: vine.boolean().optional(),
+    role: vine.enum(['customer', 'admin'] as const).optional(),
+  })
+)

--- a/apps/api/start/routes.ts
+++ b/apps/api/start/routes.ts
@@ -16,6 +16,7 @@ const AdminCategoriesController = () => import('#controllers/admin_categories_co
 const ProductImagesController = () => import('#controllers/product_images_controller')
 const SiteConfigController = () => import('#controllers/site_config_controller')
 const AdminHomepageController = () => import('#controllers/admin_homepage_controller')
+const AdminUsersController = () => import('#controllers/admin_users_controller')
 
 router.get('/', async () => ({ hello: 'world' }))
 
@@ -99,6 +100,17 @@ router
     router.patch('intro', [AdminHomepageController, 'updateIntro'])
   })
   .prefix('/admin/homepage')
+  .use([middleware.auth(), middleware.admin()])
+
+router
+  .group(() => {
+    router.get('/', [AdminUsersController, 'index'])
+    router.get(':id', [AdminUsersController, 'show'])
+    router.patch(':id', [AdminUsersController, 'update'])
+    router.delete(':id', [AdminUsersController, 'destroy'])
+    router.post(':id/reset-password', [AdminUsersController, 'sendPasswordReset'])
+  })
+  .prefix('/admin/users')
   .use([middleware.auth(), middleware.admin()])
 
 router

--- a/apps/backoffice/app/composables/useAdminAuth.ts
+++ b/apps/backoffice/app/composables/useAdminAuth.ts
@@ -1,4 +1,4 @@
-export interface AdminUser {
+export interface AdminAuthUser {
   id: number
   email: string
   fullName: string | null
@@ -14,7 +14,7 @@ export interface AdminToken {
 }
 
 interface AdminAuthState {
-  user: AdminUser | null
+  user: AdminAuthUser | null
   token: AdminToken | null
   twoFactorEnabled: boolean
 }
@@ -29,7 +29,7 @@ export function useAdminAuth() {
     sameSite: 'lax',
     secure: false
   })
-  const userCookie = useCookie<AdminUser | null>(USER_COOKIE, {
+  const userCookie = useCookie<AdminAuthUser | null>(USER_COOKIE, {
     default: () => null,
     sameSite: 'lax',
     secure: false
@@ -48,7 +48,7 @@ export function useAdminAuth() {
 
   const isAuthenticated = computed(() => state.value.user !== null && state.value.token !== null)
 
-  function setSession(user: AdminUser, token: AdminToken, twoFactorEnabled: boolean) {
+  function setSession(user: AdminAuthUser, token: AdminToken, twoFactorEnabled: boolean) {
     state.value = { user, token, twoFactorEnabled }
     userCookie.value = user
     tokenCookie.value = token

--- a/apps/backoffice/app/composables/useApiTypes.ts
+++ b/apps/backoffice/app/composables/useApiTypes.ts
@@ -25,6 +25,50 @@ export interface AdminCategory {
   productCount?: number
 }
 
+export interface AdminUser {
+  id: number
+  email: string
+  fullName: string | null
+  phone: string | null
+  role: 'customer' | 'admin'
+  isActive: boolean
+  emailVerifiedAt: string | null
+  createdAt: string
+  accountStatus: 'active' | 'inactive' | 'pending'
+  orderCount?: number
+  totalRevenue?: number
+}
+
+export interface AdminAddress {
+  id: number
+  userId: number
+  fullName: string | null
+  line1: string
+  line2: string | null
+  city: string
+  postalCode: string
+  country: string
+  isDefault: boolean
+}
+
+export interface AdminOrder {
+  id: number
+  userId: number
+  status: string
+  subtotal: string | number
+  tax: string | number
+  total: string | number
+  createdAt: string
+}
+
+export interface AdminUserDetail {
+  user: AdminUser
+  addresses: AdminAddress[]
+  orders: AdminOrder[]
+  orderCount: number
+  totalRevenue: number
+}
+
 export interface AdminProduct {
   id: number
   name: string

--- a/apps/backoffice/app/pages/login.vue
+++ b/apps/backoffice/app/pages/login.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
-import type { AdminToken, AdminUser } from '~/composables/useAdminAuth'
+import type { AdminToken, AdminAuthUser } from '~/composables/useAdminAuth'
 
 definePageMeta({ layout: 'auth' })
 
 interface LoginSuccess {
-  user: AdminUser
+  user: AdminAuthUser
   token: AdminToken
   twoFactorEnabled: boolean
 }

--- a/apps/backoffice/app/pages/users/[id].vue
+++ b/apps/backoffice/app/pages/users/[id].vue
@@ -1,0 +1,151 @@
+<script setup lang="ts">
+import type { AdminUserDetail } from '~/composables/useApiTypes'
+
+const route = useRoute()
+const router = useRouter()
+const api = useApi()
+const toast = useToast()
+const { currency, dateTime } = useFormat()
+const id = Number(route.params.id)
+
+const { data, refresh } = await useAsyncData<AdminUserDetail>(`admin-user-${id}`, () =>
+  api<AdminUserDetail>(`/admin/users/${id}`)
+)
+
+if (!data.value) {
+  throw createError({ statusCode: 404, statusMessage: 'Utilisateur introuvable' })
+}
+
+async function toggleActive() {
+  if (!data.value) return
+  const isActive = !data.value.user.isActive
+  await api(`/admin/users/${id}`, { method: 'PATCH', body: { isActive } })
+  toast.add({ color: 'success', title: isActive ? 'Compte activé.' : 'Compte désactivé.' })
+  refresh()
+}
+
+async function sendReset() {
+  await api(`/admin/users/${id}/reset-password`, { method: 'POST' })
+  toast.add({ color: 'success', title: 'Email de réinitialisation envoyé.' })
+}
+
+async function destroy() {
+  if (!data.value) return
+  const message = `Supprimer définitivement ${data.value.user.email} ?\n\nRGPD : toutes les données personnelles seront effacées. Cette action est irréversible.`
+  if (!confirm(message)) return
+  await api(`/admin/users/${id}`, { method: 'DELETE' })
+  toast.add({ color: 'success', title: 'Utilisateur supprimé.' })
+  router.push('/users')
+}
+
+const statusBadge: Record<string, { color: 'success' | 'warning' | 'error', label: string }> = {
+  active: { color: 'success', label: 'Actif' },
+  pending: { color: 'warning', label: 'En attente de vérification' },
+  inactive: { color: 'error', label: 'Désactivé' }
+}
+</script>
+
+<template>
+  <UDashboardNavbar :title="data?.user.fullName || data?.user.email || 'Utilisateur'">
+    <template #left>
+      <UButton to="/users" icon="i-lucide-arrow-left" variant="ghost" color="neutral" label="Retour" />
+    </template>
+    <template #right>
+      <div class="flex gap-2">
+        <UButton variant="soft" :color="data?.user.isActive ? 'warning' : 'success'" :icon="data?.user.isActive ? 'i-lucide-eye-off' : 'i-lucide-eye'" :label="data?.user.isActive ? 'Désactiver' : 'Activer'" @click="toggleActive" />
+        <UButton variant="soft" color="neutral" icon="i-lucide-key-round" label="Réinitialiser MDP" @click="sendReset" />
+        <UButton variant="soft" color="error" icon="i-lucide-trash-2" label="Supprimer" :disabled="data?.user.role === 'admin'" @click="destroy" />
+      </div>
+    </template>
+  </UDashboardNavbar>
+  <UDashboardPanelContent v-if="data" class="p-4 sm:p-6">
+    <div class="grid gap-6 lg:grid-cols-3">
+      <UCard class="lg:col-span-2">
+        <template #header>
+          <h2 class="font-semibold">Informations</h2>
+        </template>
+        <dl class="grid gap-3 sm:grid-cols-2 text-sm">
+          <div>
+            <dt class="text-muted">Email</dt>
+            <dd>{{ data.user.email }}</dd>
+          </div>
+          <div>
+            <dt class="text-muted">Téléphone</dt>
+            <dd>{{ data.user.phone || '—' }}</dd>
+          </div>
+          <div>
+            <dt class="text-muted">Rôle</dt>
+            <dd>{{ data.user.role === 'admin' ? 'Administrateur' : 'Client' }}</dd>
+          </div>
+          <div>
+            <dt class="text-muted">Statut</dt>
+            <dd>
+              <UBadge :color="statusBadge[data.user.accountStatus]?.color ?? 'neutral'" variant="subtle">
+                {{ statusBadge[data.user.accountStatus]?.label ?? data.user.accountStatus }}
+              </UBadge>
+            </dd>
+          </div>
+          <div>
+            <dt class="text-muted">Inscrit le</dt>
+            <dd>{{ dateTime(data.user.createdAt) }}</dd>
+          </div>
+          <div>
+            <dt class="text-muted">Email vérifié</dt>
+            <dd>{{ data.user.emailVerifiedAt ? dateTime(data.user.emailVerifiedAt) : 'Non' }}</dd>
+          </div>
+        </dl>
+      </UCard>
+
+      <UCard>
+        <template #header>
+          <h2 class="font-semibold">Activité commerciale</h2>
+        </template>
+        <div class="space-y-2 text-sm">
+          <div class="flex justify-between"><span class="text-muted">Commandes</span><span class="font-medium">{{ data.orderCount }}</span></div>
+          <div class="flex justify-between"><span class="text-muted">Chiffre d'affaires</span><span class="font-medium">{{ currency(data.totalRevenue) }}</span></div>
+        </div>
+      </UCard>
+
+      <UCard class="lg:col-span-3">
+        <template #header>
+          <h2 class="font-semibold">Adresses ({{ data.addresses.length }})</h2>
+        </template>
+        <div v-if="!data.addresses.length" class="text-sm text-muted">Aucune adresse enregistrée.</div>
+        <div v-else class="grid gap-3 md:grid-cols-2 lg:grid-cols-3">
+          <div v-for="address in data.addresses" :key="address.id" class="rounded-lg border border-default p-3 text-sm">
+            <div class="flex items-center justify-between mb-1">
+              <p class="font-medium">{{ address.fullName || '—' }}</p>
+              <UBadge v-if="address.isDefault" color="primary" variant="subtle">Par défaut</UBadge>
+            </div>
+            <p>{{ address.line1 }}</p>
+            <p v-if="address.line2">{{ address.line2 }}</p>
+            <p>{{ address.postalCode }} {{ address.city }}</p>
+            <p class="text-muted">{{ address.country }}</p>
+          </div>
+        </div>
+      </UCard>
+
+      <UCard class="lg:col-span-3">
+        <template #header>
+          <div class="flex items-center justify-between">
+            <h2 class="font-semibold">10 dernières commandes</h2>
+            <UButton :to="`/orders?userId=${id}`" variant="link" color="neutral" size="sm" label="Toutes" />
+          </div>
+        </template>
+        <div v-if="!data.orders.length" class="text-sm text-muted">Aucune commande.</div>
+        <div v-else class="divide-y divide-default">
+          <div v-for="order in data.orders" :key="order.id" class="flex items-center justify-between py-2 text-sm first:pt-0 last:pb-0">
+            <div>
+              <p class="font-medium">#{{ order.id }}</p>
+              <p class="text-xs text-muted">{{ dateTime(order.createdAt) }}</p>
+            </div>
+            <div class="flex items-center gap-3">
+              <UBadge variant="subtle">{{ order.status }}</UBadge>
+              <span class="font-semibold">{{ currency(Number(order.total)) }}</span>
+            </div>
+          </div>
+        </div>
+      </UCard>
+    </div>
+  </UDashboardPanelContent>
+</template>

--- a/apps/backoffice/app/pages/users/index.vue
+++ b/apps/backoffice/app/pages/users/index.vue
@@ -1,0 +1,120 @@
+<script setup lang="ts">
+import type { AdminUser, Paginated } from '~/composables/useApiTypes'
+
+const api = useApi()
+const { currency, dateTime } = useFormat()
+
+const search = ref('')
+const status = ref<'all' | 'active' | 'inactive' | 'pending'>('all')
+const page = ref(1)
+const perPage = ref(25)
+
+const debouncedSearch = ref('')
+let debounceTimer: ReturnType<typeof setTimeout> | undefined
+watch(search, (value) => {
+  if (debounceTimer) clearTimeout(debounceTimer)
+  debounceTimer = setTimeout(() => {
+    debouncedSearch.value = value
+  }, 300)
+})
+
+const queryParams = computed(() => {
+  const params: Record<string, string | number> = {
+    page: page.value,
+    perPage: perPage.value,
+    status: status.value
+  }
+  if (debouncedSearch.value) params.q = debouncedSearch.value
+  return params
+})
+
+const { data, pending, refresh } = await useAsyncData<Paginated<AdminUser>>(
+  'admin-users',
+  () => api<Paginated<AdminUser>>('/admin/users', { params: queryParams.value }),
+  { watch: [queryParams] }
+)
+
+watch([debouncedSearch, status, perPage], () => { page.value = 1 })
+
+const statusItems = [
+  { label: 'Tous', value: 'all' as const },
+  { label: 'Actif', value: 'active' as const },
+  { label: 'En attente', value: 'pending' as const },
+  { label: 'Désactivé', value: 'inactive' as const }
+]
+
+const statusBadge: Record<string, { color: 'success' | 'warning' | 'error', label: string }> = {
+  active: { color: 'success', label: 'Actif' },
+  pending: { color: 'warning', label: 'En attente' },
+  inactive: { color: 'error', label: 'Désactivé' }
+}
+</script>
+
+<template>
+  <UDashboardNavbar title="Utilisateurs" />
+  <UDashboardPanelContent class="p-4 sm:p-6">
+    <UCard>
+      <template #header>
+        <div class="flex flex-wrap items-center gap-3">
+          <UInput v-model="search" icon="i-lucide-search" placeholder="Rechercher (nom, email)" class="w-64" />
+          <USelect v-model="status" :items="statusItems" class="w-48" />
+          <USelect v-model="perPage" :items="[{ label: '10', value: 10 }, { label: '25', value: 25 }, { label: '50', value: 50 }]" class="w-24" />
+          <UButton class="ml-auto" icon="i-lucide-refresh-cw" variant="ghost" color="neutral" :loading="pending" aria-label="Rafraîchir" @click="refresh()" />
+        </div>
+      </template>
+
+      <div v-if="pending && !data" class="py-12 text-center text-sm text-muted">Chargement...</div>
+      <div v-else-if="!data?.data?.length" class="py-12 text-center text-sm text-muted">
+        Aucun utilisateur ne correspond à ces filtres.
+      </div>
+      <div v-else class="overflow-x-auto">
+        <table class="min-w-full text-sm">
+          <thead class="text-left text-muted uppercase text-xs">
+            <tr>
+              <th class="px-3 py-2">Nom / Email</th>
+              <th class="px-3 py-2">Rôle</th>
+              <th class="px-3 py-2 text-right">Commandes</th>
+              <th class="px-3 py-2 text-right">CA</th>
+              <th class="px-3 py-2">Inscrit le</th>
+              <th class="px-3 py-2">Statut</th>
+              <th class="px-3 py-2 text-right">Actions</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-default">
+            <tr v-for="user in data.data" :key="user.id">
+              <td class="px-3 py-3">
+                <div class="font-medium">{{ user.fullName || '—' }}</div>
+                <div class="text-xs text-muted">{{ user.email }}</div>
+              </td>
+              <td class="px-3 py-3">
+                <UBadge :color="user.role === 'admin' ? 'primary' : 'neutral'" variant="subtle">
+                  {{ user.role === 'admin' ? 'Admin' : 'Client' }}
+                </UBadge>
+              </td>
+              <td class="px-3 py-3 text-right">{{ user.orderCount ?? 0 }}</td>
+              <td class="px-3 py-3 text-right">{{ currency(user.totalRevenue ?? 0) }}</td>
+              <td class="px-3 py-3 text-muted text-xs">{{ dateTime(user.createdAt) }}</td>
+              <td class="px-3 py-3">
+                <UBadge :color="statusBadge[user.accountStatus]?.color ?? 'neutral'" variant="subtle">
+                  {{ statusBadge[user.accountStatus]?.label ?? user.accountStatus }}
+                </UBadge>
+              </td>
+              <td class="px-3 py-3 text-right">
+                <UButton :to="`/users/${user.id}`" icon="i-lucide-arrow-right" variant="ghost" color="neutral" size="sm" aria-label="Détail" />
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <template v-if="data && data.meta.lastPage > 1" #footer>
+        <div class="flex items-center justify-between">
+          <p class="text-sm text-muted">
+            {{ data.meta.total }} utilisateur(s) — page {{ data.meta.currentPage }} / {{ data.meta.lastPage }}
+          </p>
+          <UPagination v-model:page="page" :items-per-page="perPage" :total="data.meta.total" />
+        </div>
+      </template>
+    </UCard>
+  </UDashboardPanelContent>
+</template>


### PR DESCRIPTION
Closes #31.

Adds /admin/users with name/email search, status filter (all / active / pending email verification / inactive) and pagination. Each row carries a per-user order count and total revenue (paid+ statuses) computed via a single grouped subquery. /admin/users/:id returns the user, billing addresses and last 10 orders with the same stats. Actions cover deactivate/activate toggle, send password reset (reuses the existing reset email flow), and delete with an admin-role guard.

Backoffice ships /users (table with search/status/pagination, links to detail) and /users/:id (info card, activity card, addresses grid, recent orders, action buttons in the navbar). The delete button confirms with an RGPD warning and is disabled for admin accounts. AdminUser was renamed to AdminAuthUser in the auth composable to avoid the auto-import collision with the API entity type.