### PR TITLE
feat(backoffice): orders management

### DIFF
--- a/apps/api/app/controllers/admin_orders_controller.ts
+++ b/apps/api/app/controllers/admin_orders_controller.ts
@@ -1,0 +1,82 @@
+import type { HttpContext } from '@adonisjs/core/http'
+import Order from '#models/order'
+import OrderStatusHistory from '#models/order_status_history'
+import { listOrdersValidator, updateOrderStatusValidator } from '#validators/admin_orders'
+
+export default class AdminOrdersController {
+  async index({ request }: HttpContext) {
+    const { q, status, userId, page = 1, perPage = 25 } = await listOrdersValidator.validate(
+      request.qs()
+    )
+
+    const builder = Order.query().preload('user').preload('invoice').preload('paymentMethod')
+
+    if (status && status !== 'all') builder.where('status', status)
+    if (userId) builder.where('userId', userId)
+    if (q) {
+      const pattern = `%${q}%`
+      const numeric = Number.parseInt(q, 10)
+      builder.where((sub) => {
+        sub
+          .whereHas('user', (userQuery) => {
+            userQuery.where((userSub) => {
+              userSub.whereILike('email', pattern).orWhereILike('full_name', pattern)
+            })
+          })
+          .if(!Number.isNaN(numeric), (chain) => chain.orWhere('id', numeric))
+      })
+    }
+
+    builder.orderBy('createdAt', 'desc')
+    const result = await builder.paginate(page, perPage)
+    return {
+      meta: result.getMeta(),
+      data: result.all().map((order) => ({
+        ...order.serialize(),
+        customer: order.user?.fullName || order.user?.email || 'Client',
+        customerEmail: order.user?.email ?? null,
+      })),
+    }
+  }
+
+  async show({ params }: HttpContext) {
+    const order = await Order.query()
+      .where('id', params.id)
+      .preload('user')
+      .preload('items')
+      .preload('billingAddress')
+      .preload('shippingAddress')
+      .preload('paymentMethod')
+      .preload('invoice')
+      .firstOrFail()
+
+    const history = await OrderStatusHistory.query()
+      .where('orderId', order.id)
+      .preload('changedBy')
+      .orderBy('createdAt', 'asc')
+
+    return { order, history }
+  }
+
+  async updateStatus({ auth, params, request }: HttpContext) {
+    const admin = auth.getUserOrFail()
+    const order = await Order.findOrFail(params.id)
+    const { status, note } = await request.validateUsing(updateOrderStatusValidator)
+
+    if (order.status === status) return { order }
+
+    const fromStatus = order.status
+    order.status = status
+    await order.save()
+
+    await OrderStatusHistory.create({
+      orderId: order.id,
+      fromStatus,
+      toStatus: status,
+      note: note ?? null,
+      changedByUserId: admin.id,
+    })
+
+    return { order }
+  }
+}

--- a/apps/api/app/models/order_status_history.ts
+++ b/apps/api/app/models/order_status_history.ts
@@ -1,0 +1,36 @@
+import { DateTime } from 'luxon'
+import { BaseModel, belongsTo, column } from '@adonisjs/lucid/orm'
+import type { BelongsTo } from '@adonisjs/lucid/types/relations'
+import Order from '#models/order'
+import User from '#models/user'
+
+export default class OrderStatusHistory extends BaseModel {
+  static table = 'order_status_history'
+
+  @column({ isPrimary: true })
+  declare id: number
+
+  @column()
+  declare orderId: number
+
+  @column()
+  declare fromStatus: string | null
+
+  @column()
+  declare toStatus: string
+
+  @column()
+  declare note: string | null
+
+  @column()
+  declare changedByUserId: number | null
+
+  @column.dateTime({ autoCreate: true })
+  declare createdAt: DateTime
+
+  @belongsTo(() => Order)
+  declare order: BelongsTo<typeof Order>
+
+  @belongsTo(() => User, { foreignKey: 'changedByUserId' })
+  declare changedBy: BelongsTo<typeof User>
+}

--- a/apps/api/app/validators/admin_orders.ts
+++ b/apps/api/app/validators/admin_orders.ts
@@ -1,0 +1,28 @@
+import vine from '@vinejs/vine'
+
+export const ORDER_STATUSES = [
+  'pending',
+  'paid',
+  'processing',
+  'shipped',
+  'delivered',
+  'cancelled',
+  'refunded',
+] as const
+
+export const listOrdersValidator = vine.compile(
+  vine.object({
+    q: vine.string().trim().minLength(1).maxLength(120).optional(),
+    status: vine.enum(['all', ...ORDER_STATUSES] as const).optional(),
+    userId: vine.number().positive().optional(),
+    page: vine.number().withoutDecimals().min(1).optional(),
+    perPage: vine.number().withoutDecimals().min(1).max(100).optional(),
+  })
+)
+
+export const updateOrderStatusValidator = vine.compile(
+  vine.object({
+    status: vine.enum(ORDER_STATUSES),
+    note: vine.string().trim().maxLength(500).optional(),
+  })
+)

--- a/apps/api/database/migrations/1773900000001_create_order_status_history_table.ts
+++ b/apps/api/database/migrations/1773900000001_create_order_status_history_table.ts
@@ -1,0 +1,34 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'order_status_history'
+
+  async up() {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table
+        .integer('order_id')
+        .unsigned()
+        .notNullable()
+        .references('id')
+        .inTable('orders')
+        .onDelete('CASCADE')
+      table.string('from_status', 32).nullable()
+      table.string('to_status', 32).notNullable()
+      table.text('note').nullable()
+      table
+        .integer('changed_by_user_id')
+        .unsigned()
+        .nullable()
+        .references('id')
+        .inTable('users')
+        .onDelete('SET NULL')
+      table.timestamp('created_at', { useTz: true }).notNullable().defaultTo(this.now())
+      table.index(['order_id', 'created_at'])
+    })
+  }
+
+  async down() {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/apps/api/start/routes.ts
+++ b/apps/api/start/routes.ts
@@ -17,6 +17,7 @@ const ProductImagesController = () => import('#controllers/product_images_contro
 const SiteConfigController = () => import('#controllers/site_config_controller')
 const AdminHomepageController = () => import('#controllers/admin_homepage_controller')
 const AdminUsersController = () => import('#controllers/admin_users_controller')
+const AdminOrdersController = () => import('#controllers/admin_orders_controller')
 
 router.get('/', async () => ({ hello: 'world' }))
 
@@ -100,6 +101,15 @@ router
     router.patch('intro', [AdminHomepageController, 'updateIntro'])
   })
   .prefix('/admin/homepage')
+  .use([middleware.auth(), middleware.admin()])
+
+router
+  .group(() => {
+    router.get('/', [AdminOrdersController, 'index'])
+    router.get(':id', [AdminOrdersController, 'show'])
+    router.patch(':id/status', [AdminOrdersController, 'updateStatus'])
+  })
+  .prefix('/admin/orders')
   .use([middleware.auth(), middleware.admin()])
 
 router

--- a/apps/backoffice/app/composables/useApiTypes.ts
+++ b/apps/backoffice/app/composables/useApiTypes.ts
@@ -51,14 +51,56 @@ export interface AdminAddress {
   isDefault: boolean
 }
 
+export type OrderStatus =
+  | 'pending'
+  | 'paid'
+  | 'processing'
+  | 'shipped'
+  | 'delivered'
+  | 'cancelled'
+  | 'refunded'
+
 export interface AdminOrder {
   id: number
   userId: number
-  status: string
+  status: OrderStatus
   subtotal: string | number
   tax: string | number
+  shippingCost?: string | number
   total: string | number
+  stripePaymentIntentId?: string | null
   createdAt: string
+  customer?: string
+  customerEmail?: string | null
+  paymentMethod?: { brand?: string | null, lastFour?: string | null } | null
+  invoice?: { id: number, invoiceNumber: string, pdfPath?: string | null } | null
+}
+
+export interface AdminOrderItem {
+  id: number
+  productName: string
+  quantity: number
+  unitPrice: string | number
+  total: string | number
+}
+
+export interface AdminOrderStatusHistoryEntry {
+  id: number
+  fromStatus: string | null
+  toStatus: string
+  note: string | null
+  createdAt: string
+  changedBy?: { id: number, fullName: string | null, email: string } | null
+}
+
+export interface AdminOrderDetail {
+  order: AdminOrder & {
+    items: AdminOrderItem[]
+    billingAddress: AdminAddress | null
+    shippingAddress: AdminAddress | null
+    user: AdminUser | null
+  }
+  history: AdminOrderStatusHistoryEntry[]
 }
 
 export interface AdminUserDetail {

--- a/apps/backoffice/app/composables/useOrderStatus.ts
+++ b/apps/backoffice/app/composables/useOrderStatus.ts
@@ -1,0 +1,19 @@
+import type { OrderStatus } from '~/composables/useApiTypes'
+
+const STATUS_META: Record<OrderStatus, { label: string, color: 'warning' | 'primary' | 'success' | 'error' | 'neutral' }> = {
+  pending: { label: 'En attente', color: 'warning' },
+  paid: { label: 'Payée', color: 'primary' },
+  processing: { label: 'En préparation', color: 'primary' },
+  shipped: { label: 'Expédiée', color: 'primary' },
+  delivered: { label: 'Livrée', color: 'success' },
+  cancelled: { label: 'Annulée', color: 'error' },
+  refunded: { label: 'Remboursée', color: 'neutral' }
+}
+
+export function useOrderStatus() {
+  return {
+    statuses: Object.keys(STATUS_META) as OrderStatus[],
+    label: (status: string) => STATUS_META[status as OrderStatus]?.label ?? status,
+    color: (status: string) => STATUS_META[status as OrderStatus]?.color ?? 'neutral'
+  }
+}

--- a/apps/backoffice/app/pages/orders/[id].vue
+++ b/apps/backoffice/app/pages/orders/[id].vue
@@ -1,0 +1,195 @@
+<script setup lang="ts">
+import type { AdminOrderDetail, OrderStatus } from '~/composables/useApiTypes'
+
+const route = useRoute()
+const api = useApi()
+const toast = useToast()
+const { currency, dateTime } = useFormat()
+const { statuses, label, color } = useOrderStatus()
+const id = Number(route.params.id)
+
+const { data, refresh } = await useAsyncData<AdminOrderDetail>(`admin-order-${id}`, () =>
+  api<AdminOrderDetail>(`/admin/orders/${id}`)
+)
+
+if (!data.value) {
+  throw createError({ statusCode: 404, statusMessage: 'Commande introuvable' })
+}
+
+const newStatus = ref<OrderStatus>('pending')
+const note = ref('')
+const submitting = ref(false)
+
+watch(data, (v) => { if (v) newStatus.value = v.order.status }, { immediate: true })
+
+async function changeStatus() {
+  if (!newStatus.value || newStatus.value === data.value?.order.status) return
+  submitting.value = true
+  try {
+    await api(`/admin/orders/${id}/status`, {
+      method: 'PATCH',
+      body: { status: newStatus.value, note: note.value || undefined }
+    })
+    toast.add({ color: 'success', title: 'Statut mis à jour.' })
+    note.value = ''
+    refresh()
+  } catch (err) {
+    toast.add({ color: 'error', title: extractMessage(err, 'Erreur lors de la mise à jour.') })
+  } finally {
+    submitting.value = false
+  }
+}
+
+const statusItems = computed(() => statuses.map((s) => ({ label: label(s), value: s })))
+
+function extractMessage(err: unknown, fallback: string) {
+  if (err && typeof err === 'object' && 'data' in err) {
+    const data = (err as { data?: { message?: string } }).data
+    if (data?.message) return data.message
+  }
+  return fallback
+}
+</script>
+
+<template>
+  <UDashboardNavbar :title="`Commande #${id}`">
+    <template #left>
+      <UButton to="/orders" icon="i-lucide-arrow-left" variant="ghost" color="neutral" label="Retour" />
+    </template>
+  </UDashboardNavbar>
+  <UDashboardPanelContent v-if="data" class="p-4 sm:p-6">
+    <div class="grid gap-6 lg:grid-cols-3">
+      <UCard class="lg:col-span-2">
+        <template #header>
+          <div class="flex items-center justify-between">
+            <h2 class="font-semibold">Articles</h2>
+            <UBadge :color="color(data.order.status)" variant="subtle">{{ label(data.order.status) }}</UBadge>
+          </div>
+        </template>
+        <table class="min-w-full text-sm">
+          <thead class="text-left text-muted uppercase text-xs">
+            <tr>
+              <th class="py-2">Produit</th>
+              <th class="py-2 text-right">Qté</th>
+              <th class="py-2 text-right">PU</th>
+              <th class="py-2 text-right">Total</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-default">
+            <tr v-for="item in data.order.items" :key="item.id">
+              <td class="py-2">{{ item.productName }}</td>
+              <td class="py-2 text-right">{{ item.quantity }}</td>
+              <td class="py-2 text-right">{{ currency(Number(item.unitPrice)) }}</td>
+              <td class="py-2 text-right font-medium">{{ currency(Number(item.total)) }}</td>
+            </tr>
+          </tbody>
+          <tfoot class="border-t border-default text-sm">
+            <tr>
+              <td colspan="3" class="py-2 text-right text-muted">Sous-total</td>
+              <td class="py-2 text-right">{{ currency(Number(data.order.subtotal)) }}</td>
+            </tr>
+            <tr>
+              <td colspan="3" class="py-2 text-right text-muted">TVA</td>
+              <td class="py-2 text-right">{{ currency(Number(data.order.tax)) }}</td>
+            </tr>
+            <tr v-if="data.order.shippingCost">
+              <td colspan="3" class="py-2 text-right text-muted">Livraison</td>
+              <td class="py-2 text-right">{{ currency(Number(data.order.shippingCost)) }}</td>
+            </tr>
+            <tr>
+              <td colspan="3" class="py-2 text-right font-semibold">Total TTC</td>
+              <td class="py-2 text-right font-semibold">{{ currency(Number(data.order.total)) }}</td>
+            </tr>
+          </tfoot>
+        </table>
+      </UCard>
+
+      <UCard>
+        <template #header>
+          <h2 class="font-semibold">Client & paiement</h2>
+        </template>
+        <div class="space-y-3 text-sm">
+          <div>
+            <p class="text-muted text-xs">Client</p>
+            <p class="font-medium">{{ data.order.user?.fullName || '—' }}</p>
+            <p class="text-muted">{{ data.order.user?.email }}</p>
+          </div>
+          <div v-if="data.order.paymentMethod">
+            <p class="text-muted text-xs">Moyen de paiement</p>
+            <p>{{ data.order.paymentMethod.brand }} •••• {{ data.order.paymentMethod.lastFour }}</p>
+          </div>
+          <div v-if="data.order.stripePaymentIntentId">
+            <p class="text-muted text-xs">Stripe Payment Intent</p>
+            <code class="text-xs">{{ data.order.stripePaymentIntentId }}</code>
+          </div>
+          <div v-if="data.order.invoice">
+            <p class="text-muted text-xs">Facture</p>
+            <p class="font-medium">{{ data.order.invoice.invoiceNumber }}</p>
+          </div>
+        </div>
+      </UCard>
+
+      <UCard class="lg:col-span-2">
+        <template #header>
+          <h2 class="font-semibold">Adresses</h2>
+        </template>
+        <div class="grid gap-4 md:grid-cols-2 text-sm">
+          <div>
+            <p class="text-muted text-xs mb-1">Facturation</p>
+            <template v-if="data.order.billingAddress">
+              <p>{{ data.order.billingAddress.line1 }}</p>
+              <p v-if="data.order.billingAddress.line2">{{ data.order.billingAddress.line2 }}</p>
+              <p>{{ data.order.billingAddress.postalCode }} {{ data.order.billingAddress.city }}</p>
+              <p class="text-muted">{{ data.order.billingAddress.country }}</p>
+            </template>
+            <p v-else class="text-muted">—</p>
+          </div>
+          <div>
+            <p class="text-muted text-xs mb-1">Livraison</p>
+            <template v-if="data.order.shippingAddress">
+              <p>{{ data.order.shippingAddress.line1 }}</p>
+              <p v-if="data.order.shippingAddress.line2">{{ data.order.shippingAddress.line2 }}</p>
+              <p>{{ data.order.shippingAddress.postalCode }} {{ data.order.shippingAddress.city }}</p>
+              <p class="text-muted">{{ data.order.shippingAddress.country }}</p>
+            </template>
+            <p v-else class="text-muted">—</p>
+          </div>
+        </div>
+      </UCard>
+
+      <UCard>
+        <template #header>
+          <h2 class="font-semibold">Changer le statut</h2>
+        </template>
+        <div class="space-y-3">
+          <USelect v-model="newStatus" :items="statusItems" class="w-full" />
+          <UTextarea v-model="note" :rows="2" placeholder="Commentaire (optionnel)" class="w-full" />
+          <UButton block :loading="submitting" :disabled="newStatus === data.order.status" label="Mettre à jour" @click="changeStatus" />
+        </div>
+      </UCard>
+
+      <UCard class="lg:col-span-3">
+        <template #header>
+          <h2 class="font-semibold">Historique des statuts</h2>
+        </template>
+        <ol v-if="data.history.length" class="space-y-3">
+          <li v-for="entry in data.history" :key="entry.id" class="flex items-start gap-3 text-sm">
+            <UIcon name="i-lucide-circle-dot" class="size-4 mt-0.5" :class="`text-${color(entry.toStatus) === 'neutral' ? 'gray-500' : color(entry.toStatus)}-500`" />
+            <div>
+              <p>
+                <span v-if="entry.fromStatus" class="text-muted">{{ label(entry.fromStatus) }} →</span>
+                <span class="font-medium">{{ label(entry.toStatus) }}</span>
+              </p>
+              <p class="text-xs text-muted">
+                {{ dateTime(entry.createdAt) }}
+                <span v-if="entry.changedBy"> · par {{ entry.changedBy.fullName || entry.changedBy.email }}</span>
+              </p>
+              <p v-if="entry.note" class="text-sm mt-1">{{ entry.note }}</p>
+            </div>
+          </li>
+        </ol>
+        <p v-else class="text-sm text-muted">Aucun changement de statut enregistré pour l'instant.</p>
+      </UCard>
+    </div>
+  </UDashboardPanelContent>
+</template>

--- a/apps/backoffice/app/pages/orders/index.vue
+++ b/apps/backoffice/app/pages/orders/index.vue
@@ -1,0 +1,108 @@
+<script setup lang="ts">
+import type { AdminOrder, OrderStatus, Paginated } from '~/composables/useApiTypes'
+
+const route = useRoute()
+const api = useApi()
+const { currency, dateTime } = useFormat()
+const { statuses, label, color } = useOrderStatus()
+
+const search = ref('')
+const status = ref<'all' | OrderStatus>('all')
+const userId = ref<number | null>(route.query.userId ? Number(route.query.userId) : null)
+const page = ref(1)
+const perPage = ref(25)
+
+const debouncedSearch = ref('')
+let debounceTimer: ReturnType<typeof setTimeout> | undefined
+watch(search, (value) => {
+  if (debounceTimer) clearTimeout(debounceTimer)
+  debounceTimer = setTimeout(() => { debouncedSearch.value = value }, 300)
+})
+
+const queryParams = computed(() => {
+  const params: Record<string, string | number> = { page: page.value, perPage: perPage.value, status: status.value }
+  if (debouncedSearch.value) params.q = debouncedSearch.value
+  if (userId.value) params.userId = userId.value
+  return params
+})
+
+const { data, pending, refresh } = await useAsyncData<Paginated<AdminOrder>>(
+  'admin-orders',
+  () => api<Paginated<AdminOrder>>('/admin/orders', { params: queryParams.value }),
+  { watch: [queryParams] }
+)
+
+watch([debouncedSearch, status, perPage], () => { page.value = 1 })
+
+const statusItems = computed(() => [
+  { label: 'Tous statuts', value: 'all' as const },
+  ...statuses.map((s) => ({ label: label(s), value: s }))
+])
+</script>
+
+<template>
+  <UDashboardNavbar title="Commandes" />
+  <UDashboardPanelContent class="p-4 sm:p-6">
+    <UCard>
+      <template #header>
+        <div class="flex flex-wrap items-center gap-3">
+          <UInput v-model="search" icon="i-lucide-search" placeholder="N° commande, nom, email" class="w-64" />
+          <USelect v-model="status" :items="statusItems" class="w-48" />
+          <USelect v-model="perPage" :items="[{ label: '10', value: 10 }, { label: '25', value: 25 }, { label: '50', value: 50 }]" class="w-24" />
+          <UBadge v-if="userId" color="primary" variant="subtle" class="ml-2">
+            Utilisateur #{{ userId }}
+            <button class="ml-2" @click="userId = null">×</button>
+          </UBadge>
+          <UButton class="ml-auto" icon="i-lucide-refresh-cw" variant="ghost" color="neutral" :loading="pending" aria-label="Rafraîchir" @click="refresh()" />
+        </div>
+      </template>
+
+      <div v-if="pending && !data" class="py-12 text-center text-sm text-muted">Chargement...</div>
+      <div v-else-if="!data?.data?.length" class="py-12 text-center text-sm text-muted">Aucune commande.</div>
+      <div v-else class="overflow-x-auto">
+        <table class="min-w-full text-sm">
+          <thead class="text-left text-muted uppercase text-xs">
+            <tr>
+              <th class="px-3 py-2">N°</th>
+              <th class="px-3 py-2">Date</th>
+              <th class="px-3 py-2">Client</th>
+              <th class="px-3 py-2 text-right">Montant TTC</th>
+              <th class="px-3 py-2">Paiement</th>
+              <th class="px-3 py-2">Statut</th>
+              <th class="px-3 py-2 text-right">Actions</th>
+            </tr>
+          </thead>
+          <tbody class="divide-y divide-default">
+            <tr v-for="order in data.data" :key="order.id">
+              <td class="px-3 py-3 font-medium">#{{ order.id }}</td>
+              <td class="px-3 py-3 text-muted text-xs">{{ dateTime(order.createdAt) }}</td>
+              <td class="px-3 py-3">
+                <div class="font-medium">{{ order.customer }}</div>
+                <div v-if="order.customerEmail" class="text-xs text-muted">{{ order.customerEmail }}</div>
+              </td>
+              <td class="px-3 py-3 text-right font-semibold">{{ currency(Number(order.total)) }}</td>
+              <td class="px-3 py-3 text-xs">
+                <span v-if="order.paymentMethod">{{ order.paymentMethod.brand }} •••• {{ order.paymentMethod.lastFour }}</span>
+                <span v-else-if="order.stripePaymentIntentId" class="text-muted">Stripe</span>
+                <span v-else class="text-muted">—</span>
+              </td>
+              <td class="px-3 py-3">
+                <UBadge :color="color(order.status)" variant="subtle">{{ label(order.status) }}</UBadge>
+              </td>
+              <td class="px-3 py-3 text-right">
+                <UButton :to="`/orders/${order.id}`" icon="i-lucide-arrow-right" variant="ghost" color="neutral" size="sm" aria-label="Détail" />
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <template v-if="data && data.meta.lastPage > 1" #footer>
+        <div class="flex items-center justify-between">
+          <p class="text-sm text-muted">{{ data.meta.total }} commande(s) — page {{ data.meta.currentPage }} / {{ data.meta.lastPage }}</p>
+          <UPagination v-model:page="page" :items-per-page="perPage" :total="data.meta.total" />
+        </div>
+      </template>
+    </UCard>
+  </UDashboardPanelContent>
+</template>


### PR DESCRIPTION
Closes #32.

API: /admin/orders list with search by id/name/email, status filter, optional userId scope, and pagination. /admin/orders/:id preloads items, user, billing/shipping, payment method and invoice. PATCH /admin/orders/:id/status updates status and writes a row to a new order_status_history table that records from/to, optional note and the admin who made the change.

Backoffice: /orders renders the table with id, date, customer (name + email), TTC amount, payment summary and a colour-coded status badge (yellow / blue / green / red mapping). Detail page lays out items with totals, customer/payment card, addresses, a status changer with optional comment, and a chronological status history. A new useOrderStatus composable centralises label and color mapping.