### PR TITLE
feat(backoffice): invoices and credit notes management

### DIFF
--- a/apps/api/app/controllers/admin_invoices_controller.ts
+++ b/apps/api/app/controllers/admin_invoices_controller.ts
@@ -1,0 +1,151 @@
+import type { HttpContext } from '@adonisjs/core/http'
+import { DateTime } from 'luxon'
+import { createReadStream } from 'node:fs'
+import fs from 'node:fs/promises'
+import Invoice from '#models/invoice'
+import CreditNote from '#models/credit_note'
+import Order from '#models/order'
+import {
+  createCreditNoteValidator,
+  listInvoicesValidator,
+} from '#validators/admin_invoices'
+import { generateCreditNotePdf } from '#services/credit_note_generator'
+import { sendInvoiceCopy, sendCreditNoteCopy } from '#services/account_mailer'
+
+export default class AdminInvoicesController {
+  async indexInvoices({ request }: HttpContext) {
+    const { q, page = 1, perPage = 25 } = await listInvoicesValidator.validate(request.qs())
+    const builder = Invoice.query()
+      .preload('order', (orderQuery) => orderQuery.preload('user'))
+
+    if (q) {
+      const pattern = `%${q}%`
+      builder.where((sub) => {
+        sub.whereILike('invoiceNumber', pattern).orWhereHas('order', (orderQuery) => {
+          orderQuery.whereHas('user', (userQuery) => {
+            userQuery.where((userSub) => {
+              userSub.whereILike('email', pattern).orWhereILike('full_name', pattern)
+            })
+          })
+        })
+      })
+    }
+
+    builder.orderBy('issuedAt', 'desc')
+    const result = await builder.paginate(page, perPage)
+    return {
+      meta: result.getMeta(),
+      data: result.all().map((invoice) => ({
+        ...invoice.serialize(),
+        customer: invoice.order?.user?.fullName || invoice.order?.user?.email || 'Client',
+        customerEmail: invoice.order?.user?.email ?? null,
+        orderStatus: invoice.order?.status ?? null,
+      })),
+    }
+  }
+
+  async indexCreditNotes({ request }: HttpContext) {
+    const { q, page = 1, perPage = 25 } = await listInvoicesValidator.validate(request.qs())
+    const builder = CreditNote.query()
+      .preload('invoice', (invoiceQuery) =>
+        invoiceQuery.preload('order', (orderQuery) => orderQuery.preload('user'))
+      )
+
+    if (q) {
+      const pattern = `%${q}%`
+      builder.where((sub) => {
+        sub
+          .whereILike('creditNoteNumber', pattern)
+          .orWhereHas('invoice', (invoiceQuery) => invoiceQuery.whereILike('invoiceNumber', pattern))
+      })
+    }
+
+    builder.orderBy('issuedAt', 'desc')
+    const result = await builder.paginate(page, perPage)
+    return {
+      meta: result.getMeta(),
+      data: result.all().map((cn) => ({
+        ...cn.serialize(),
+        invoiceNumber: cn.invoice?.invoiceNumber ?? null,
+        customer: cn.invoice?.order?.user?.fullName || cn.invoice?.order?.user?.email || 'Client',
+      })),
+    }
+  }
+
+  async downloadInvoice({ params, response }: HttpContext) {
+    const invoice = await Invoice.findOrFail(params.id)
+    if (!invoice.pdfPath) {
+      return response.notFound({ message: 'PDF indisponible.' })
+    }
+    response.header('Content-Type', 'application/pdf')
+    response.header('Content-Disposition', `attachment; filename="${invoice.invoiceNumber}.pdf"`)
+    return response.stream(createReadStream(invoice.pdfPath))
+  }
+
+  async resendInvoice({ params, response }: HttpContext) {
+    const invoice = await Invoice.findOrFail(params.id)
+    await invoice.load('order', (orderQuery) => orderQuery.preload('user'))
+    const user = invoice.order?.user
+    if (!user) return response.notFound({ message: 'Destinataire introuvable.' })
+    await sendInvoiceCopy(user, invoice.invoiceNumber)
+    return response.accepted({ message: 'Email envoyé.' })
+  }
+
+  async createCreditNote({ request, response }: HttpContext) {
+    const { invoiceId, amount, reason } = await request.validateUsing(createCreditNoteValidator)
+    const invoice = await Invoice.findOrFail(invoiceId)
+    await invoice.load('order', (orderQuery) => orderQuery.preload('user'))
+
+    const order = invoice.order
+    const user = order?.user
+    if (!order || !user) {
+      return response.unprocessableEntity({ message: 'Commande ou client introuvable.' })
+    }
+
+    const lastCount = await CreditNote.query().count('* as total')
+    const total = Number(lastCount[0]?.$extras?.total ?? 0) + 1
+    const creditNoteNumber = `AVO-${DateTime.now().toFormat('yyyyLLdd')}-${String(total).padStart(5, '0')}`
+
+    const creditNote = await CreditNote.create({
+      invoiceId: invoice.id,
+      creditNoteNumber,
+      amount,
+      reason: reason ?? null,
+      issuedAt: DateTime.now(),
+    })
+
+    const customerName = user.fullName ?? user.email
+    creditNote.pdfPath = await generateCreditNotePdf(creditNote, invoice, customerName)
+    await creditNote.save()
+
+    return response.created({ creditNote })
+  }
+
+  async downloadCreditNote({ params, response }: HttpContext) {
+    const creditNote = await CreditNote.findOrFail(params.id)
+    if (!creditNote.pdfPath) {
+      return response.notFound({ message: 'PDF indisponible.' })
+    }
+    response.header('Content-Type', 'application/pdf')
+    response.header(
+      'Content-Disposition',
+      `attachment; filename="${creditNote.creditNoteNumber}.pdf"`
+    )
+    return response.stream(createReadStream(creditNote.pdfPath))
+  }
+
+  async resendCreditNote({ params, response }: HttpContext) {
+    const creditNote = await CreditNote.findOrFail(params.id)
+    await creditNote.load('invoice', (invoiceQuery) =>
+      invoiceQuery.preload('order', (orderQuery) => orderQuery.preload('user'))
+    )
+    const user = creditNote.invoice?.order?.user
+    if (!user) return response.notFound({ message: 'Destinataire introuvable.' })
+    await sendCreditNoteCopy(user, creditNote.creditNoteNumber)
+    return response.accepted({ message: 'Email envoyé.' })
+  }
+}
+
+// Force eager loading helpers
+void Order
+void fs

--- a/apps/api/app/services/account_mailer.ts
+++ b/apps/api/app/services/account_mailer.ts
@@ -8,7 +8,7 @@ function buildLink(path: string, token: string) {
   return `${base}${path}?token=${encodeURIComponent(token)}`
 }
 
-async function deliver(payload: { to: string; subject: string; html: string; link: string }) {
+async function deliver(payload: { to: string; subject: string; html: string; link?: string }) {
   if (env.get('MAIL_DRIVER', 'log') === 'log') {
     logger.info({ to: payload.to, subject: payload.subject, link: payload.link }, 'mail.log')
     return
@@ -20,6 +20,24 @@ async function deliver(payload: { to: string; subject: string; html: string; lin
   } catch (err) {
     logger.error({ err, to: payload.to, subject: payload.subject, link: payload.link }, 'mail.send.failed')
   }
+}
+
+export async function sendInvoiceCopy(user: User, invoiceNumber: string) {
+  await deliver({
+    to: user.email,
+    subject: `Votre facture ${invoiceNumber}`,
+    html: `<p>Bonjour ${user.fullName ?? ''},</p>
+      <p>Votre facture ${invoiceNumber} est disponible dans votre espace client.</p>`,
+  })
+}
+
+export async function sendCreditNoteCopy(user: User, creditNoteNumber: string) {
+  await deliver({
+    to: user.email,
+    subject: `Avoir ${creditNoteNumber}`,
+    html: `<p>Bonjour ${user.fullName ?? ''},</p>
+      <p>Un avoir ${creditNoteNumber} a été émis sur votre compte. Vous pouvez le consulter dans votre espace client.</p>`,
+  })
 }
 
 export async function sendEmailVerification(user: User, token: string, email: string) {

--- a/apps/api/app/services/credit_note_generator.ts
+++ b/apps/api/app/services/credit_note_generator.ts
@@ -1,0 +1,55 @@
+import path from 'node:path'
+import fs from 'node:fs/promises'
+import { createWriteStream } from 'node:fs'
+import PDFDocument from 'pdfkit'
+import app from '@adonisjs/core/services/app'
+import type CreditNote from '#models/credit_note'
+import type Invoice from '#models/invoice'
+
+const CREDIT_NOTE_DIR = 'storage/credit-notes'
+
+export async function generateCreditNotePdf(
+  creditNote: CreditNote,
+  invoice: Invoice,
+  customerName: string
+): Promise<string> {
+  const dir = app.makePath(CREDIT_NOTE_DIR)
+  await fs.mkdir(dir, { recursive: true })
+  const filePath = path.join(dir, `${creditNote.creditNoteNumber}.pdf`)
+
+  await new Promise<void>((resolve, reject) => {
+    const doc = new PDFDocument({ size: 'A4', margin: 50 })
+    const stream = createWriteStream(filePath)
+    stream.on('finish', resolve)
+    stream.on('error', reject)
+    doc.pipe(stream)
+
+    doc.fontSize(20).text('Althea Systems', { align: 'left' })
+    doc.fontSize(10).fillColor('#475569').text('Matériel médical de pointe')
+    doc.moveDown(2)
+
+    doc.fontSize(16).fillColor('#0f172a').text(`Avoir ${creditNote.creditNoteNumber}`)
+    doc.fontSize(10).fillColor('#475569').text(`Date : ${new Date().toLocaleDateString('fr-FR')}`)
+    doc.text(`Facture liée : ${invoice.invoiceNumber}`)
+    doc.moveDown()
+
+    doc.fontSize(11).fillColor('#0f172a').text('Émis pour')
+    doc.fontSize(10).fillColor('#475569').text(customerName)
+    doc.moveDown()
+
+    if (creditNote.reason) {
+      doc.fontSize(11).fillColor('#0f172a').text('Motif')
+      doc.fontSize(10).fillColor('#475569').text(creditNote.reason)
+      doc.moveDown()
+    }
+
+    doc.fontSize(12).fillColor('#0f172a').text(`Montant : ${formatPrice(creditNote.amount)}`, { align: 'right' })
+    doc.end()
+  })
+
+  return filePath
+}
+
+function formatPrice(value: number): string {
+  return new Intl.NumberFormat('fr-FR', { style: 'currency', currency: 'EUR' }).format(Number(value))
+}

--- a/apps/api/app/validators/admin_invoices.ts
+++ b/apps/api/app/validators/admin_invoices.ts
@@ -1,0 +1,17 @@
+import vine from '@vinejs/vine'
+
+export const listInvoicesValidator = vine.compile(
+  vine.object({
+    q: vine.string().trim().minLength(1).maxLength(120).optional(),
+    page: vine.number().withoutDecimals().min(1).optional(),
+    perPage: vine.number().withoutDecimals().min(1).max(100).optional(),
+  })
+)
+
+export const createCreditNoteValidator = vine.compile(
+  vine.object({
+    invoiceId: vine.number().positive(),
+    amount: vine.number().positive(),
+    reason: vine.string().trim().maxLength(500).optional(),
+  })
+)

--- a/apps/api/start/routes.ts
+++ b/apps/api/start/routes.ts
@@ -18,6 +18,7 @@ const SiteConfigController = () => import('#controllers/site_config_controller')
 const AdminHomepageController = () => import('#controllers/admin_homepage_controller')
 const AdminUsersController = () => import('#controllers/admin_users_controller')
 const AdminOrdersController = () => import('#controllers/admin_orders_controller')
+const AdminInvoicesController = () => import('#controllers/admin_invoices_controller')
 
 router.get('/', async () => ({ hello: 'world' }))
 
@@ -110,6 +111,19 @@ router
     router.patch(':id/status', [AdminOrdersController, 'updateStatus'])
   })
   .prefix('/admin/orders')
+  .use([middleware.auth(), middleware.admin()])
+
+router
+  .group(() => {
+    router.get('invoices', [AdminInvoicesController, 'indexInvoices'])
+    router.get('invoices/:id/download', [AdminInvoicesController, 'downloadInvoice'])
+    router.post('invoices/:id/resend', [AdminInvoicesController, 'resendInvoice'])
+    router.post('credit-notes', [AdminInvoicesController, 'createCreditNote'])
+    router.get('credit-notes', [AdminInvoicesController, 'indexCreditNotes'])
+    router.get('credit-notes/:id/download', [AdminInvoicesController, 'downloadCreditNote'])
+    router.post('credit-notes/:id/resend', [AdminInvoicesController, 'resendCreditNote'])
+  })
+  .prefix('/admin')
   .use([middleware.auth(), middleware.admin()])
 
 router

--- a/apps/backoffice/app/composables/useApiTypes.ts
+++ b/apps/backoffice/app/composables/useApiTypes.ts
@@ -111,6 +111,32 @@ export interface AdminUserDetail {
   totalRevenue: number
 }
 
+export interface AdminInvoice {
+  id: number
+  invoiceNumber: string
+  orderId: number
+  subtotal: string | number
+  tax: string | number
+  total: string | number
+  pdfPath: string | null
+  issuedAt: string
+  customer: string
+  customerEmail: string | null
+  orderStatus: string | null
+}
+
+export interface AdminCreditNote {
+  id: number
+  creditNoteNumber: string
+  invoiceId: number
+  invoiceNumber: string | null
+  amount: string | number
+  reason: string | null
+  pdfPath: string | null
+  issuedAt: string
+  customer: string
+}
+
 export interface AdminProduct {
   id: number
   name: string

--- a/apps/backoffice/app/pages/invoices.vue
+++ b/apps/backoffice/app/pages/invoices.vue
@@ -1,0 +1,236 @@
+<script setup lang="ts">
+import type { AdminCreditNote, AdminInvoice, Paginated } from '~/composables/useApiTypes'
+
+const config = useRuntimeConfig()
+const api = useApi()
+const { token } = useAdminAuth()
+const toast = useToast()
+const { currency, dateTime } = useFormat()
+
+const tab = ref<'invoices' | 'credit-notes'>('invoices')
+
+const { data: invoices, refresh: refreshInvoices, pending: invoicesPending } =
+  await useAsyncData<Paginated<AdminInvoice>>(
+    'admin-invoices',
+    () => api<Paginated<AdminInvoice>>('/admin/invoices', { params: { perPage: 50 } })
+  )
+
+const { data: creditNotes, refresh: refreshCreditNotes, pending: creditNotesPending } =
+  await useAsyncData<Paginated<AdminCreditNote>>(
+    'admin-credit-notes',
+    () => api<Paginated<AdminCreditNote>>('/admin/credit-notes', { params: { perPage: 50 } })
+  )
+
+const showCreateCredit = ref(false)
+const creditForm = reactive({
+  invoiceId: null as number | null,
+  amount: 0,
+  reason: ''
+})
+
+async function downloadInvoice(invoice: AdminInvoice) {
+  await downloadPdf(`/admin/invoices/${invoice.id}/download`, `${invoice.invoiceNumber}.pdf`)
+}
+
+async function downloadCreditNote(cn: AdminCreditNote) {
+  await downloadPdf(`/admin/credit-notes/${cn.id}/download`, `${cn.creditNoteNumber}.pdf`)
+}
+
+async function downloadPdf(path: string, filename: string) {
+  try {
+    const res = await fetch(`${config.public.apiBase}${path}`, {
+      headers: { Authorization: `Bearer ${token.value?.value ?? ''}` }
+    })
+    if (!res.ok) throw new Error(String(res.status))
+    const blob = await res.blob()
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = filename
+    a.click()
+    URL.revokeObjectURL(url)
+  } catch (err) {
+    toast.add({ color: 'error', title: 'Téléchargement impossible.' })
+  }
+}
+
+async function resendInvoice(invoice: AdminInvoice) {
+  await api(`/admin/invoices/${invoice.id}/resend`, { method: 'POST' })
+  toast.add({ color: 'success', title: `Email de la facture ${invoice.invoiceNumber} envoyé.` })
+}
+
+async function resendCreditNote(cn: AdminCreditNote) {
+  await api(`/admin/credit-notes/${cn.id}/resend`, { method: 'POST' })
+  toast.add({ color: 'success', title: `Email de l'avoir ${cn.creditNoteNumber} envoyé.` })
+}
+
+function openCreateCredit(invoice: AdminInvoice) {
+  creditForm.invoiceId = invoice.id
+  creditForm.amount = Number(invoice.total)
+  creditForm.reason = ''
+  showCreateCredit.value = true
+}
+
+async function submitCreditNote() {
+  if (!creditForm.invoiceId || creditForm.amount <= 0) return
+  try {
+    await api('/admin/credit-notes', {
+      method: 'POST',
+      body: {
+        invoiceId: creditForm.invoiceId,
+        amount: creditForm.amount,
+        reason: creditForm.reason || undefined
+      }
+    })
+    toast.add({ color: 'success', title: 'Avoir créé.' })
+    showCreateCredit.value = false
+    refreshCreditNotes()
+  } catch (err) {
+    toast.add({ color: 'error', title: extractMessage(err, 'Création impossible.') })
+  }
+}
+
+const orderStatusBadge: Record<string, { color: 'success' | 'warning' | 'error' | 'primary' | 'neutral', label: string }> = {
+  paid: { color: 'success', label: 'Payée' },
+  pending: { color: 'warning', label: 'En attente' },
+  cancelled: { color: 'error', label: 'Annulée' },
+  refunded: { color: 'neutral', label: 'Remboursée' }
+}
+
+function extractMessage(err: unknown, fallback: string) {
+  if (err && typeof err === 'object' && 'data' in err) {
+    const data = (err as { data?: { message?: string } }).data
+    if (data?.message) return data.message
+  }
+  return fallback
+}
+</script>
+
+<template>
+  <UDashboardNavbar title="Factures & avoirs" />
+  <UDashboardPanelContent class="p-4 sm:p-6">
+    <UCard>
+      <template #header>
+        <UTabs
+          v-model="tab"
+          :items="[
+            { label: `Factures (${invoices?.meta?.total ?? 0})`, value: 'invoices' },
+            { label: `Avoirs (${creditNotes?.meta?.total ?? 0})`, value: 'credit-notes' }
+          ]"
+        />
+      </template>
+
+      <div v-if="tab === 'invoices'">
+        <div v-if="!invoices?.data?.length" class="py-12 text-center text-sm text-muted">Aucune facture.</div>
+        <div v-else class="overflow-x-auto">
+          <table class="min-w-full text-sm">
+            <thead class="text-left text-muted uppercase text-xs">
+              <tr>
+                <th class="px-3 py-2">N°</th>
+                <th class="px-3 py-2">Date</th>
+                <th class="px-3 py-2">Client</th>
+                <th class="px-3 py-2">Commande</th>
+                <th class="px-3 py-2">Statut</th>
+                <th class="px-3 py-2 text-right">Montant TTC</th>
+                <th class="px-3 py-2 text-right">Actions</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-default">
+              <tr v-for="invoice in invoices.data" :key="invoice.id">
+                <td class="px-3 py-3 font-medium">{{ invoice.invoiceNumber }}</td>
+                <td class="px-3 py-3 text-muted text-xs">{{ dateTime(invoice.issuedAt) }}</td>
+                <td class="px-3 py-3">
+                  <div class="font-medium">{{ invoice.customer }}</div>
+                  <div v-if="invoice.customerEmail" class="text-xs text-muted">{{ invoice.customerEmail }}</div>
+                </td>
+                <td class="px-3 py-3">
+                  <NuxtLink :to="`/orders/${invoice.orderId}`" class="text-primary hover:underline">#{{ invoice.orderId }}</NuxtLink>
+                </td>
+                <td class="px-3 py-3">
+                  <UBadge v-if="invoice.orderStatus" :color="orderStatusBadge[invoice.orderStatus]?.color ?? 'neutral'" variant="subtle">
+                    {{ orderStatusBadge[invoice.orderStatus]?.label ?? invoice.orderStatus }}
+                  </UBadge>
+                </td>
+                <td class="px-3 py-3 text-right font-semibold">{{ currency(Number(invoice.total)) }}</td>
+                <td class="px-3 py-3 text-right">
+                  <div class="flex justify-end gap-1">
+                    <UButton icon="i-lucide-download" variant="ghost" color="neutral" size="sm" aria-label="Télécharger" :disabled="!invoice.pdfPath" @click="downloadInvoice(invoice)" />
+                    <UButton icon="i-lucide-mail" variant="ghost" color="neutral" size="sm" aria-label="Renvoyer par email" @click="resendInvoice(invoice)" />
+                    <UButton icon="i-lucide-rotate-ccw" variant="ghost" color="warning" size="sm" aria-label="Créer un avoir" @click="openCreateCredit(invoice)" />
+                  </div>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <template v-if="invoicesPending">
+          <USkeleton class="h-16 mt-3" />
+        </template>
+      </div>
+
+      <div v-else>
+        <div v-if="!creditNotes?.data?.length" class="py-12 text-center text-sm text-muted">Aucun avoir.</div>
+        <div v-else class="overflow-x-auto">
+          <table class="min-w-full text-sm">
+            <thead class="text-left text-muted uppercase text-xs">
+              <tr>
+                <th class="px-3 py-2">N°</th>
+                <th class="px-3 py-2">Facture liée</th>
+                <th class="px-3 py-2">Date</th>
+                <th class="px-3 py-2">Client</th>
+                <th class="px-3 py-2">Motif</th>
+                <th class="px-3 py-2 text-right">Montant</th>
+                <th class="px-3 py-2 text-right">Actions</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-default">
+              <tr v-for="cn in creditNotes.data" :key="cn.id">
+                <td class="px-3 py-3 font-medium">{{ cn.creditNoteNumber }}</td>
+                <td class="px-3 py-3">{{ cn.invoiceNumber || '—' }}</td>
+                <td class="px-3 py-3 text-muted text-xs">{{ dateTime(cn.issuedAt) }}</td>
+                <td class="px-3 py-3">{{ cn.customer }}</td>
+                <td class="px-3 py-3 text-xs text-muted max-w-xs">
+                  <span class="line-clamp-1">{{ cn.reason || '—' }}</span>
+                </td>
+                <td class="px-3 py-3 text-right font-semibold text-error">- {{ currency(Number(cn.amount)) }}</td>
+                <td class="px-3 py-3 text-right">
+                  <div class="flex justify-end gap-1">
+                    <UButton icon="i-lucide-download" variant="ghost" color="neutral" size="sm" aria-label="Télécharger" :disabled="!cn.pdfPath" @click="downloadCreditNote(cn)" />
+                    <UButton icon="i-lucide-mail" variant="ghost" color="neutral" size="sm" aria-label="Renvoyer par email" @click="resendCreditNote(cn)" />
+                  </div>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <template v-if="creditNotesPending">
+          <USkeleton class="h-16 mt-3" />
+        </template>
+      </div>
+    </UCard>
+
+    <UModal v-model:open="showCreateCredit">
+      <template #content>
+        <UCard>
+          <template #header>
+            <h2 class="font-semibold">Créer un avoir</h2>
+          </template>
+          <div class="space-y-3">
+            <UFormField label="Montant" required>
+              <UInput v-model.number="creditForm.amount" type="number" step="0.01" min="0.01" class="w-full" />
+            </UFormField>
+            <UFormField label="Motif">
+              <UTextarea v-model="creditForm.reason" :rows="3" class="w-full" placeholder="Retour produit, geste commercial…" />
+            </UFormField>
+          </div>
+          <template #footer>
+            <div class="flex justify-end gap-2">
+              <UButton variant="ghost" color="neutral" label="Annuler" @click="showCreateCredit = false" />
+              <UButton color="primary" label="Créer l'avoir" @click="submitCreditNote" />
+            </div>
+          </template>
+        </UCard>
+      </template>
+    </UModal>
+  </UDashboardPanelContent>
+</template>


### PR DESCRIPTION
Closes #33.

API exposes admin endpoints for invoices and credit notes: list invoices with search across number / customer name / email, list credit notes, download PDFs (uses the existing invoice generator and a new credit-note generator that writes to storage/credit-notes), resend the matching customer email for either, and create a credit note tied to an invoice (auto-numbered AVO-yyyyMMdd-NNNNN).

Backoffice ships /invoices with a tabbed UCard: invoices table (number, date, client, order link, status, amount, download / resend / create-credit-note buttons) and credit notes table (number, linked invoice, date, client, reason, amount shown negative, download / resend). The create-credit-note modal pre-fills the invoice total and asks for an optional reason. Downloads stream the PDF via fetch + Blob using the admin bearer token.