### PR TITLE
feat: contact form page

### DIFF
--- a/apps/api/app/controllers/contact_controller.ts
+++ b/apps/api/app/controllers/contact_controller.ts
@@ -1,0 +1,22 @@
+import type { HttpContext } from '@adonisjs/core/http'
+import ContactMessage from '#models/contact_message'
+import { submitContactValidator } from '#validators/contact'
+
+export default class ContactController {
+  async store({ auth, request, response }: HttpContext) {
+    const payload = await request.validateUsing(submitContactValidator)
+    const userId = auth.user?.id ?? null
+    const message = await ContactMessage.create({
+      userId,
+      name: payload.name,
+      email: payload.email,
+      subject: payload.subject,
+      message: payload.message,
+      isRead: false,
+    })
+    return response.created({
+      message: 'Votre message a bien été envoyé. Notre équipe vous répondra rapidement.',
+      id: message.id,
+    })
+  }
+}

--- a/apps/api/app/validators/contact.ts
+++ b/apps/api/app/validators/contact.ts
@@ -1,0 +1,10 @@
+import vine from '@vinejs/vine'
+
+export const submitContactValidator = vine.compile(
+  vine.object({
+    name: vine.string().trim().minLength(2).maxLength(120),
+    email: vine.string().trim().email().normalizeEmail(),
+    subject: vine.string().trim().minLength(2).maxLength(160),
+    message: vine.string().trim().minLength(10).maxLength(4000),
+  })
+)

--- a/apps/api/start/routes.ts
+++ b/apps/api/start/routes.ts
@@ -15,6 +15,7 @@ const CategoriesController = () => import('#controllers/categories_controller')
 const AdminCategoriesController = () => import('#controllers/admin_categories_controller')
 const ProductImagesController = () => import('#controllers/product_images_controller')
 const SiteConfigController = () => import('#controllers/site_config_controller')
+const ContactController = () => import('#controllers/contact_controller')
 const AdminHomepageController = () => import('#controllers/admin_homepage_controller')
 const AdminUsersController = () => import('#controllers/admin_users_controller')
 const AdminOrdersController = () => import('#controllers/admin_orders_controller')
@@ -23,6 +24,8 @@ const AdminInvoicesController = () => import('#controllers/admin_invoices_contro
 router.get('/', async () => ({ hello: 'world' }))
 
 router.get('/site-config/homepage', [SiteConfigController, 'homepage'])
+
+router.post('/contact', [ContactController, 'store'])
 
 router
   .group(() => {

--- a/apps/storefront/app/pages/contact.vue
+++ b/apps/storefront/app/pages/contact.vue
@@ -1,0 +1,159 @@
+<script setup lang="ts">
+const api = useApi()
+const toast = useToast()
+const { user } = useAuth()
+
+const state = reactive({
+  name: user.value?.fullName ?? '',
+  email: user.value?.email ?? '',
+  subject: '',
+  message: ''
+})
+const errors = ref<Record<string, string>>({})
+const submitting = ref(false)
+const submitted = ref(false)
+
+useSeoMeta({
+  title: 'Contact — Althea Systems',
+  description: 'Une question, une commande spécifique ? Notre équipe vous répond rapidement.'
+})
+
+function validate() {
+  const next: Record<string, string> = {}
+  if (state.name.trim().length < 2) next.name = 'Votre nom est requis.'
+  if (!/^.+@.+\..+$/.test(state.email)) next.email = 'Adresse email invalide.'
+  if (state.subject.trim().length < 2) next.subject = 'Sujet requis.'
+  if (state.message.trim().length < 10) next.message = 'Message trop court (10 caractères minimum).'
+  errors.value = next
+  return Object.keys(next).length === 0
+}
+
+async function submit() {
+  if (submitting.value) return
+  if (!validate()) return
+  submitting.value = true
+  try {
+    await api('/contact', {
+      method: 'POST',
+      body: {
+        name: state.name,
+        email: state.email,
+        subject: state.subject,
+        message: state.message
+      }
+    })
+    submitted.value = true
+    toast.success('Message envoyé. Notre équipe vous répondra rapidement.')
+    state.subject = ''
+    state.message = ''
+  } catch (err) {
+    toast.error(extractMessage(err, "Impossible d'envoyer le message."))
+  } finally {
+    submitting.value = false
+  }
+}
+
+function extractMessage(err: unknown, fallback: string) {
+  if (err && typeof err === 'object' && 'data' in err) {
+    const data = (err as { data?: { message?: string, errors?: Array<{ message: string }> } }).data
+    if (data?.errors?.[0]?.message) return data.errors[0].message
+    if (data?.message) return data.message
+  }
+  return fallback
+}
+</script>
+
+<template>
+  <main class="mx-auto max-w-3xl px-4 py-10 md:px-10 md:py-16">
+    <header class="mb-8 text-center">
+      <p class="text-sm uppercase tracking-widest text-brand-500">Nous contacter</p>
+      <h1 class="mt-2 font-display text-3xl text-brand-text md:text-4xl">Une question, un besoin spécifique ?</h1>
+      <p class="mt-3 text-neutral-600">
+        Notre équipe vous répond généralement sous 24 heures ouvrées. Pour les urgences SAV,
+        précisez-le dans le sujet.
+      </p>
+    </header>
+
+    <form
+      v-if="!submitted"
+      class="space-y-5 rounded-2xl border border-neutral-100 bg-white p-6 shadow-sm md:p-8"
+      @submit.prevent="submit"
+    >
+      <div class="grid gap-5 md:grid-cols-2">
+        <label class="block text-sm font-medium">
+          Nom
+          <input
+            v-model="state.name"
+            type="text"
+            required
+            autocomplete="name"
+            class="mt-1 w-full rounded-lg border border-neutral-200 px-3 py-2 outline-none focus:border-brand-400"
+          />
+          <AppFormError v-if="errors.name" :message="errors.name" />
+        </label>
+        <label class="block text-sm font-medium">
+          Email
+          <input
+            v-model="state.email"
+            type="email"
+            required
+            autocomplete="email"
+            class="mt-1 w-full rounded-lg border border-neutral-200 px-3 py-2 outline-none focus:border-brand-400"
+          />
+          <AppFormError v-if="errors.email" :message="errors.email" />
+        </label>
+      </div>
+      <label class="block text-sm font-medium">
+        Sujet
+        <input
+          v-model="state.subject"
+          type="text"
+          required
+          class="mt-1 w-full rounded-lg border border-neutral-200 px-3 py-2 outline-none focus:border-brand-400"
+        />
+        <AppFormError v-if="errors.subject" :message="errors.subject" />
+      </label>
+      <label class="block text-sm font-medium">
+        Message
+        <textarea
+          v-model="state.message"
+          rows="6"
+          required
+          class="mt-1 w-full rounded-lg border border-neutral-200 px-3 py-2 outline-none focus:border-brand-400"
+        />
+        <AppFormError v-if="errors.message" :message="errors.message" />
+      </label>
+      <div class="flex justify-end">
+        <button
+          type="submit"
+          :disabled="submitting"
+          class="rounded-lg bg-brand-500 px-6 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-brand-600 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {{ submitting ? 'Envoi...' : 'Envoyer le message' }}
+        </button>
+      </div>
+    </form>
+
+    <div
+      v-else
+      class="rounded-2xl border border-brand-200 bg-brand-50 p-8 text-center"
+    >
+      <div class="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-brand-500 text-white">
+        <svg viewBox="0 0 24 24" class="h-6 w-6" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="m5 13 4 4L19 7" stroke-linecap="round" stroke-linejoin="round" />
+        </svg>
+      </div>
+      <h2 class="font-display text-xl text-brand-text">Message bien reçu</h2>
+      <p class="mt-2 text-sm text-neutral-700">
+        Merci {{ state.name }}. Notre équipe vous recontacte sous peu à <strong>{{ state.email }}</strong>.
+      </p>
+      <button
+        type="button"
+        class="mt-5 rounded-lg border border-brand-300 px-5 py-2 text-sm font-semibold text-brand-text transition-colors hover:bg-brand-100"
+        @click="submitted = false"
+      >
+        Envoyer un autre message
+      </button>
+    </div>
+  </main>
+</template>


### PR DESCRIPTION
Closes #35.

API exposes POST /contact (public) which validates name, email, subject and message, persists a ContactMessage and pre-fills user_id when the visitor is logged in.

Storefront ships /contact with client-side validation, the user's session prefilled into name/email when available, a submit handler that surfaces both a toast and an inline confirmation card, and a button to send another message. Backoffice review of submissions is already wired through the existing dashboard alert badge and will get a dedicated table with #37.