### PR TITLE
fix(backoffice): scrollable dashboard panel content

### DIFF
--- a/apps/backoffice/app/pages/categories/[id].vue
+++ b/apps/backoffice/app/pages/categories/[id].vue
@@ -35,9 +35,9 @@ async function destroy() {
       <UButton color="error" variant="soft" icon="i-lucide-trash-2" label="Supprimer" @click="destroy" />
     </template>
   </UDashboardNavbar>
-  <UDashboardPanelContent class="p-4 sm:p-6">
+  <div class="flex flex-col gap-4 sm:gap-6 flex-1 overflow-y-auto p-4 sm:p-6">
     <UCard v-if="category">
       <CategoryForm :category="category" :parents="categories ?? []" @saved="refresh()" />
     </UCard>
-  </UDashboardPanelContent>
+  </div>
 </template>

--- a/apps/backoffice/app/pages/categories/index.vue
+++ b/apps/backoffice/app/pages/categories/index.vue
@@ -96,7 +96,7 @@ async function bulkSetStatus(isActive: boolean) {
       <UButton to="/categories/new" icon="i-lucide-plus" label="Nouvelle catégorie" />
     </template>
   </UDashboardNavbar>
-  <UDashboardPanelContent class="p-4 sm:p-6">
+  <div class="flex flex-col gap-4 sm:gap-6 flex-1 overflow-y-auto p-4 sm:p-6">
     <UCard>
       <template #header>
         <div class="flex items-center justify-between gap-3">
@@ -187,5 +187,5 @@ async function bulkSetStatus(isActive: boolean) {
         </table>
       </div>
     </UCard>
-  </UDashboardPanelContent>
+  </div>
 </template>

--- a/apps/backoffice/app/pages/categories/new.vue
+++ b/apps/backoffice/app/pages/categories/new.vue
@@ -13,9 +13,9 @@ const { data: parents } = await useAsyncData<AdminCategory[]>('admin-categories-
       <UButton to="/categories" icon="i-lucide-arrow-left" variant="ghost" color="neutral" label="Retour" />
     </template>
   </UDashboardNavbar>
-  <UDashboardPanelContent class="p-4 sm:p-6">
+  <div class="flex flex-col gap-4 sm:gap-6 flex-1 overflow-y-auto p-4 sm:p-6">
     <UCard>
       <CategoryForm :parents="parents ?? []" />
     </UCard>
-  </UDashboardPanelContent>
+  </div>
 </template>

--- a/apps/backoffice/app/pages/homepage.vue
+++ b/apps/backoffice/app/pages/homepage.vue
@@ -123,7 +123,7 @@ function extractMessage(err: unknown, fallback: string) {
 
 <template>
   <UDashboardNavbar title="Carrousel d'accueil" />
-  <UDashboardPanelContent class="p-4 sm:p-6">
+  <div class="flex flex-col gap-4 sm:gap-6 flex-1 overflow-y-auto p-4 sm:p-6">
     <div class="space-y-6 max-w-4xl">
       <UCard>
         <template #header>
@@ -215,5 +215,5 @@ function extractMessage(err: unknown, fallback: string) {
         </template>
       </UCard>
     </div>
-  </UDashboardPanelContent>
+  </div>
 </template>

--- a/apps/backoffice/app/pages/index.vue
+++ b/apps/backoffice/app/pages/index.vue
@@ -76,7 +76,7 @@ const statusColor: Record<string, 'primary' | 'success' | 'warning' | 'error' | 
     </template>
   </UDashboardNavbar>
 
-  <UDashboardPanelContent class="p-4 sm:p-6">
+  <div class="flex flex-col gap-4 sm:gap-6 flex-1 overflow-y-auto p-4 sm:p-6">
     <div class="space-y-6">
       <header>
         <p class="text-sm text-muted">Bienvenue</p>
@@ -162,5 +162,5 @@ const statusColor: Record<string, 'primary' | 'success' | 'warning' | 'error' | 
         </UCard>
       </section>
     </div>
-  </UDashboardPanelContent>
+  </div>
 </template>

--- a/apps/backoffice/app/pages/invoices.vue
+++ b/apps/backoffice/app/pages/invoices.vue
@@ -108,7 +108,7 @@ function extractMessage(err: unknown, fallback: string) {
 
 <template>
   <UDashboardNavbar title="Factures & avoirs" />
-  <UDashboardPanelContent class="p-4 sm:p-6">
+  <div class="flex flex-col gap-4 sm:gap-6 flex-1 overflow-y-auto p-4 sm:p-6">
     <UCard>
       <template #header>
         <UTabs
@@ -232,5 +232,5 @@ function extractMessage(err: unknown, fallback: string) {
         </UCard>
       </template>
     </UModal>
-  </UDashboardPanelContent>
+  </div>
 </template>

--- a/apps/backoffice/app/pages/orders/[id].vue
+++ b/apps/backoffice/app/pages/orders/[id].vue
@@ -57,7 +57,7 @@ function extractMessage(err: unknown, fallback: string) {
       <UButton to="/orders" icon="i-lucide-arrow-left" variant="ghost" color="neutral" label="Retour" />
     </template>
   </UDashboardNavbar>
-  <UDashboardPanelContent v-if="data" class="p-4 sm:p-6">
+  <div v-if="data" class="flex flex-col gap-4 sm:gap-6 flex-1 overflow-y-auto p-4 sm:p-6">
     <div class="grid gap-6 lg:grid-cols-3">
       <UCard class="lg:col-span-2">
         <template #header>
@@ -191,5 +191,5 @@ function extractMessage(err: unknown, fallback: string) {
         <p v-else class="text-sm text-muted">Aucun changement de statut enregistré pour l'instant.</p>
       </UCard>
     </div>
-  </UDashboardPanelContent>
+  </div>
 </template>

--- a/apps/backoffice/app/pages/orders/index.vue
+++ b/apps/backoffice/app/pages/orders/index.vue
@@ -42,7 +42,7 @@ const statusItems = computed(() => [
 
 <template>
   <UDashboardNavbar title="Commandes" />
-  <UDashboardPanelContent class="p-4 sm:p-6">
+  <div class="flex flex-col gap-4 sm:gap-6 flex-1 overflow-y-auto p-4 sm:p-6">
     <UCard>
       <template #header>
         <div class="flex flex-wrap items-center gap-3">
@@ -104,5 +104,5 @@ const statusItems = computed(() => [
         </div>
       </template>
     </UCard>
-  </UDashboardPanelContent>
+  </div>
 </template>

--- a/apps/backoffice/app/pages/products/[id].vue
+++ b/apps/backoffice/app/pages/products/[id].vue
@@ -40,9 +40,9 @@ async function destroy() {
       <UButton color="error" variant="soft" icon="i-lucide-trash-2" label="Supprimer" @click="destroy" />
     </template>
   </UDashboardNavbar>
-  <UDashboardPanelContent class="p-4 sm:p-6">
+  <div class="flex flex-col gap-4 sm:gap-6 flex-1 overflow-y-auto p-4 sm:p-6">
     <UCard v-if="product">
       <ProductForm :product="product" :categories="categories ?? []" @saved="refresh()" />
     </UCard>
-  </UDashboardPanelContent>
+  </div>
 </template>

--- a/apps/backoffice/app/pages/products/index.vue
+++ b/apps/backoffice/app/pages/products/index.vue
@@ -110,7 +110,7 @@ function quote(value: string) {
     </template>
   </UDashboardNavbar>
 
-  <UDashboardPanelContent class="p-4 sm:p-6">
+  <div class="flex flex-col gap-4 sm:gap-6 flex-1 overflow-y-auto p-4 sm:p-6">
     <UCard>
       <template #header>
         <div class="flex flex-wrap items-center gap-3">
@@ -222,5 +222,5 @@ function quote(value: string) {
         </div>
       </template>
     </UCard>
-  </UDashboardPanelContent>
+  </div>
 </template>

--- a/apps/backoffice/app/pages/products/new.vue
+++ b/apps/backoffice/app/pages/products/new.vue
@@ -13,9 +13,9 @@ const { data: categories } = await useAsyncData<AdminCategory[]>('admin-categori
       <UButton to="/products" icon="i-lucide-arrow-left" variant="ghost" color="neutral" label="Retour" />
     </template>
   </UDashboardNavbar>
-  <UDashboardPanelContent class="p-4 sm:p-6">
+  <div class="flex flex-col gap-4 sm:gap-6 flex-1 overflow-y-auto p-4 sm:p-6">
     <UCard>
       <ProductForm :categories="categories ?? []" />
     </UCard>
-  </UDashboardPanelContent>
+  </div>
 </template>

--- a/apps/backoffice/app/pages/security.vue
+++ b/apps/backoffice/app/pages/security.vue
@@ -76,7 +76,7 @@ function extractMessage(err: unknown, fallback: string) {
 
 <template>
   <UDashboardNavbar title="Sécurité" />
-  <UDashboardPanelContent class="p-4 sm:p-6">
+  <div class="flex flex-col gap-4 sm:gap-6 flex-1 overflow-y-auto p-4 sm:p-6">
     <div class="grid gap-6 max-w-3xl">
       <UCard>
         <template #header>
@@ -142,5 +142,5 @@ function extractMessage(err: unknown, fallback: string) {
         </ul>
       </UCard>
     </div>
-  </UDashboardPanelContent>
+  </div>
 </template>

--- a/apps/backoffice/app/pages/users/[id].vue
+++ b/apps/backoffice/app/pages/users/[id].vue
@@ -58,7 +58,7 @@ const statusBadge: Record<string, { color: 'success' | 'warning' | 'error', labe
       </div>
     </template>
   </UDashboardNavbar>
-  <UDashboardPanelContent v-if="data" class="p-4 sm:p-6">
+  <div v-if="data" class="flex flex-col gap-4 sm:gap-6 flex-1 overflow-y-auto p-4 sm:p-6">
     <div class="grid gap-6 lg:grid-cols-3">
       <UCard class="lg:col-span-2">
         <template #header>
@@ -147,5 +147,5 @@ const statusBadge: Record<string, { color: 'success' | 'warning' | 'error', labe
         </div>
       </UCard>
     </div>
-  </UDashboardPanelContent>
+  </div>
 </template>

--- a/apps/backoffice/app/pages/users/index.vue
+++ b/apps/backoffice/app/pages/users/index.vue
@@ -52,7 +52,7 @@ const statusBadge: Record<string, { color: 'success' | 'warning' | 'error', labe
 
 <template>
   <UDashboardNavbar title="Utilisateurs" />
-  <UDashboardPanelContent class="p-4 sm:p-6">
+  <div class="flex flex-col gap-4 sm:gap-6 flex-1 overflow-y-auto p-4 sm:p-6">
     <UCard>
       <template #header>
         <div class="flex flex-wrap items-center gap-3">
@@ -116,5 +116,5 @@ const statusBadge: Record<string, { color: 'success' | 'warning' | 'error', labe
         </div>
       </template>
     </UCard>
-  </UDashboardPanelContent>
+  </div>
 </template>


### PR DESCRIPTION
Replaces the placeholder UDashboardPanelContent (which doesn't exist in Nuxt UI v4) with a real div carrying flex-1 overflow-y-auto so long pages now scroll inside the panel instead of overflowing the viewport.