### PR TITLE
feat: real-time chatbot widget

### DIFF
--- a/apps/api/app/controllers/chatbot_controller.ts
+++ b/apps/api/app/controllers/chatbot_controller.ts
@@ -1,0 +1,96 @@
+import type { HttpContext } from '@adonisjs/core/http'
+import { DateTime } from 'luxon'
+import ChatbotSession from '#models/chatbot_session'
+import ChatbotMessage from '#models/chatbot_message'
+import {
+  escalateValidator,
+  postMessageValidator,
+  startSessionValidator,
+} from '#validators/chatbot'
+import { FAQ_SHORTCUTS, reply, welcomeMessage } from '#services/chatbot_brain'
+
+export default class ChatbotController {
+  async start({ auth, request, response }: HttpContext) {
+    const payload = await request.validateUsing(startSessionValidator)
+    const session = await ChatbotSession.create({
+      userId: auth.user?.id ?? null,
+      visitorName: payload.name ?? auth.user?.fullName ?? null,
+      visitorEmail: payload.email ?? auth.user?.email ?? null,
+      subject: payload.subject ?? null,
+      escalated: false,
+      isRead: false,
+    })
+
+    const greeting = await ChatbotMessage.create({
+      sessionId: session.id,
+      role: 'bot',
+      content: welcomeMessage(),
+      intent: 'welcome',
+    })
+
+    return response.created({
+      session,
+      messages: [greeting],
+      faqShortcuts: FAQ_SHORTCUTS,
+    })
+  }
+
+  async postMessage({ params, request, response }: HttpContext) {
+    const session = await ChatbotSession.findOrFail(params.id)
+    const { content } = await request.validateUsing(postMessageValidator)
+
+    const userMessage = await ChatbotMessage.create({
+      sessionId: session.id,
+      role: 'user',
+      content,
+    })
+
+    const messages = [userMessage]
+
+    if (session.escalated) {
+      return response.created({ messages })
+    }
+
+    const brain = reply(content)
+    const botMessage = await ChatbotMessage.create({
+      sessionId: session.id,
+      role: 'bot',
+      content: brain.content,
+      intent: brain.intent,
+    })
+    messages.push(botMessage)
+
+    if (brain.shouldEscalate && !session.escalated) {
+      session.escalated = true
+      session.escalatedAt = DateTime.now()
+      session.isRead = false
+      await session.save()
+    }
+
+    return response.created({ messages, session })
+  }
+
+  async escalate({ params, request, response }: HttpContext) {
+    const session = await ChatbotSession.findOrFail(params.id)
+    const payload = await request.validateUsing(escalateValidator)
+
+    session.merge({
+      visitorName: payload.name ?? session.visitorName,
+      visitorEmail: payload.email,
+      subject: payload.subject ?? session.subject,
+      escalated: true,
+      escalatedAt: session.escalatedAt ?? DateTime.now(),
+      isRead: false,
+    })
+    await session.save()
+
+    const note = await ChatbotMessage.create({
+      sessionId: session.id,
+      role: 'bot',
+      content: `Merci ${payload.name ?? ''}. Un conseiller va prendre contact à ${payload.email}.`.trim(),
+      intent: 'escalation-confirmed',
+    })
+
+    return response.accepted({ session, message: note })
+  }
+}

--- a/apps/api/app/models/chatbot_message.ts
+++ b/apps/api/app/models/chatbot_message.ts
@@ -1,0 +1,29 @@
+import { DateTime } from 'luxon'
+import { BaseModel, belongsTo, column } from '@adonisjs/lucid/orm'
+import type { BelongsTo } from '@adonisjs/lucid/types/relations'
+import ChatbotSession from '#models/chatbot_session'
+
+export type ChatbotRole = 'user' | 'bot' | 'agent'
+
+export default class ChatbotMessage extends BaseModel {
+  @column({ isPrimary: true })
+  declare id: number
+
+  @column()
+  declare sessionId: number
+
+  @column()
+  declare role: ChatbotRole
+
+  @column()
+  declare content: string
+
+  @column()
+  declare intent: string | null
+
+  @column.dateTime({ autoCreate: true })
+  declare createdAt: DateTime
+
+  @belongsTo(() => ChatbotSession, { foreignKey: 'sessionId' })
+  declare session: BelongsTo<typeof ChatbotSession>
+}

--- a/apps/api/app/models/chatbot_session.ts
+++ b/apps/api/app/models/chatbot_session.ts
@@ -1,0 +1,43 @@
+import { DateTime } from 'luxon'
+import { BaseModel, belongsTo, column, hasMany } from '@adonisjs/lucid/orm'
+import type { BelongsTo, HasMany } from '@adonisjs/lucid/types/relations'
+import User from '#models/user'
+import ChatbotMessage from '#models/chatbot_message'
+
+export default class ChatbotSession extends BaseModel {
+  @column({ isPrimary: true })
+  declare id: number
+
+  @column()
+  declare userId: number | null
+
+  @column()
+  declare visitorName: string | null
+
+  @column()
+  declare visitorEmail: string | null
+
+  @column()
+  declare subject: string | null
+
+  @column()
+  declare escalated: boolean
+
+  @column.dateTime()
+  declare escalatedAt: DateTime | null
+
+  @column()
+  declare isRead: boolean
+
+  @column.dateTime({ autoCreate: true })
+  declare createdAt: DateTime
+
+  @column.dateTime({ autoCreate: true, autoUpdate: true })
+  declare updatedAt: DateTime | null
+
+  @belongsTo(() => User)
+  declare user: BelongsTo<typeof User>
+
+  @hasMany(() => ChatbotMessage, { foreignKey: 'sessionId' })
+  declare messages: HasMany<typeof ChatbotMessage>
+}

--- a/apps/api/app/services/chatbot_brain.ts
+++ b/apps/api/app/services/chatbot_brain.ts
@@ -1,0 +1,108 @@
+interface FaqEntry {
+  intent: string
+  keywords: string[]
+  answer: string
+  suggestions?: string[]
+}
+
+const FAQ: FaqEntry[] = [
+  {
+    intent: 'address-change',
+    keywords: ['adresse', 'livraison', 'changer', 'modifier'],
+    answer:
+      "Vous pouvez modifier vos adresses depuis votre espace client, rubrique « Mes adresses ». Toute commande passée garde l'adresse choisie au moment de l'achat.",
+  },
+  {
+    intent: 'payment-methods',
+    keywords: ['paiement', 'carte', 'cb', 'virement', 'moyen'],
+    answer:
+      "Nous acceptons les cartes Visa, Mastercard et American Express via Stripe. Pour les marchés publics, contactez-nous pour un paiement par virement.",
+  },
+  {
+    intent: 'shipping-delay',
+    keywords: ['délai', 'délais', 'expédition', 'expedier', 'arriver', 'recevoir'],
+    answer:
+      'Les commandes sont expédiées sous 24 à 48 heures ouvrées. Le délai de livraison est généralement de 2 à 3 jours en France métropolitaine.',
+  },
+  {
+    intent: 'return-policy',
+    keywords: ['retour', 'rembourser', 'remboursement', 'sav'],
+    answer:
+      "Vous disposez de 14 jours pour retourner un produit non utilisé. Le SAV intervient sous 48h pour tout matériel défectueux. Contactez-nous via le formulaire « Contact » pour ouvrir un dossier.",
+  },
+  {
+    intent: 'invoice',
+    keywords: ['facture', 'facturation', 'devis'],
+    answer:
+      'Vos factures sont disponibles dans votre espace client, onglet « Mes commandes ». Pour un devis personnalisé, indiquez les références et quantités souhaitées.',
+  },
+  {
+    intent: 'account',
+    keywords: ['compte', 'mot de passe', 'connexion', 'login', 'inscription'],
+    answer:
+      "Vous pouvez créer un compte ou vous connecter en haut à droite. En cas d'oubli de mot de passe, utilisez le lien « Mot de passe oublié » sur la page de connexion.",
+  },
+]
+
+const ESCALATION_KEYWORDS = ['humain', 'agent', 'opérateur', 'operateur', 'conseiller', 'parler à quelqu', 'support']
+
+const FALLBACK_ANSWER =
+  "Je n'ai pas de réponse précise à cette question. Vous pouvez préciser votre demande ou cliquer sur « Parler à un conseiller » pour un suivi par notre équipe."
+
+export interface BrainReply {
+  intent: string
+  content: string
+  shouldEscalate: boolean
+  suggestions?: string[]
+}
+
+export function reply(message: string): BrainReply {
+  const normalized = normalize(message)
+
+  if (ESCALATION_KEYWORDS.some((kw) => normalized.includes(normalize(kw)))) {
+    return {
+      intent: 'escalate',
+      content:
+        'Je transmets votre demande à un conseiller. Indiquez votre adresse email ci-dessous afin que nous puissions vous recontacter.',
+      shouldEscalate: true,
+    }
+  }
+
+  for (const entry of FAQ) {
+    if (entry.keywords.some((kw) => normalized.includes(normalize(kw)))) {
+      return {
+        intent: entry.intent,
+        content: entry.answer,
+        shouldEscalate: false,
+        suggestions: entry.suggestions,
+      }
+    }
+  }
+
+  return {
+    intent: 'fallback',
+    content: FALLBACK_ANSWER,
+    shouldEscalate: false,
+  }
+}
+
+export function welcomeMessage(): string {
+  return [
+    "Bonjour, je suis l'assistant Althea. Je peux répondre instantanément aux questions courantes :",
+    '• Modifier une adresse',
+    '• Moyens de paiement acceptés',
+    '• Délais de livraison',
+    '• Retours et SAV',
+    '',
+    'Si besoin, demandez-moi de transférer la conversation à un conseiller.',
+  ].join('\n')
+}
+
+export const FAQ_SHORTCUTS = FAQ.map((entry) => ({ intent: entry.intent, label: entry.keywords[0]! }))
+
+function normalize(value: string): string {
+  return value
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '')
+}

--- a/apps/api/app/validators/chatbot.ts
+++ b/apps/api/app/validators/chatbot.ts
@@ -1,0 +1,23 @@
+import vine from '@vinejs/vine'
+
+export const startSessionValidator = vine.compile(
+  vine.object({
+    name: vine.string().trim().minLength(1).maxLength(120).optional(),
+    email: vine.string().trim().email().normalizeEmail().optional(),
+    subject: vine.string().trim().minLength(1).maxLength(160).optional(),
+  })
+)
+
+export const postMessageValidator = vine.compile(
+  vine.object({
+    content: vine.string().trim().minLength(1).maxLength(2000),
+  })
+)
+
+export const escalateValidator = vine.compile(
+  vine.object({
+    name: vine.string().trim().minLength(1).maxLength(120).optional(),
+    email: vine.string().trim().email().normalizeEmail(),
+    subject: vine.string().trim().minLength(1).maxLength(160).optional(),
+  })
+)

--- a/apps/api/database/migrations/1774000000001_create_chatbot_sessions_table.ts
+++ b/apps/api/database/migrations/1774000000001_create_chatbot_sessions_table.ts
@@ -1,0 +1,31 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'chatbot_sessions'
+
+  async up() {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table
+        .integer('user_id')
+        .unsigned()
+        .nullable()
+        .references('id')
+        .inTable('users')
+        .onDelete('SET NULL')
+      table.string('visitor_name', 120).nullable()
+      table.string('visitor_email', 160).nullable()
+      table.string('subject', 160).nullable()
+      table.boolean('escalated').notNullable().defaultTo(false)
+      table.timestamp('escalated_at', { useTz: true }).nullable()
+      table.boolean('is_read').notNullable().defaultTo(false)
+      table.timestamp('created_at', { useTz: true }).notNullable().defaultTo(this.now())
+      table.timestamp('updated_at', { useTz: true }).nullable()
+      table.index(['escalated', 'is_read'])
+    })
+  }
+
+  async down() {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/apps/api/database/migrations/1774000000002_create_chatbot_messages_table.ts
+++ b/apps/api/database/migrations/1774000000002_create_chatbot_messages_table.ts
@@ -1,0 +1,27 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'chatbot_messages'
+
+  async up() {
+    this.schema.createTable(this.tableName, (table) => {
+      table.increments('id')
+      table
+        .integer('session_id')
+        .unsigned()
+        .notNullable()
+        .references('id')
+        .inTable('chatbot_sessions')
+        .onDelete('CASCADE')
+      table.enum('role', ['user', 'bot', 'agent']).notNullable()
+      table.text('content').notNullable()
+      table.string('intent', 80).nullable()
+      table.timestamp('created_at', { useTz: true }).notNullable().defaultTo(this.now())
+      table.index(['session_id', 'created_at'])
+    })
+  }
+
+  async down() {
+    this.schema.dropTable(this.tableName)
+  }
+}

--- a/apps/api/start/routes.ts
+++ b/apps/api/start/routes.ts
@@ -16,6 +16,7 @@ const AdminCategoriesController = () => import('#controllers/admin_categories_co
 const ProductImagesController = () => import('#controllers/product_images_controller')
 const SiteConfigController = () => import('#controllers/site_config_controller')
 const ContactController = () => import('#controllers/contact_controller')
+const ChatbotController = () => import('#controllers/chatbot_controller')
 const AdminHomepageController = () => import('#controllers/admin_homepage_controller')
 const AdminUsersController = () => import('#controllers/admin_users_controller')
 const AdminOrdersController = () => import('#controllers/admin_orders_controller')
@@ -26,6 +27,14 @@ router.get('/', async () => ({ hello: 'world' }))
 router.get('/site-config/homepage', [SiteConfigController, 'homepage'])
 
 router.post('/contact', [ContactController, 'store'])
+
+router
+  .group(() => {
+    router.post('sessions', [ChatbotController, 'start'])
+    router.post('sessions/:id/messages', [ChatbotController, 'postMessage'])
+    router.post('sessions/:id/escalate', [ChatbotController, 'escalate'])
+  })
+  .prefix('/chatbot')
 
 router
   .group(() => {

--- a/apps/storefront/app/components/AppChatbot.vue
+++ b/apps/storefront/app/components/AppChatbot.vue
@@ -1,0 +1,307 @@
+<script setup lang="ts">
+interface ChatbotMessage {
+  id: number
+  role: 'user' | 'bot' | 'agent'
+  content: string
+  intent: string | null
+  createdAt: string
+}
+
+interface ChatbotSession {
+  id: number
+  visitorName: string | null
+  visitorEmail: string | null
+  subject: string | null
+  escalated: boolean
+}
+
+interface FaqShortcut {
+  intent: string
+  label: string
+}
+
+const SESSION_KEY = 'althea_chatbot_session'
+
+const api = useApi()
+const { user } = useAuth()
+
+const open = ref(false)
+const initialising = ref(false)
+const sending = ref(false)
+const escalating = ref(false)
+const session = ref<ChatbotSession | null>(null)
+const messages = ref<ChatbotMessage[]>([])
+const shortcuts = ref<FaqShortcut[]>([])
+const draft = ref('')
+const escalateForm = reactive({
+  name: user.value?.fullName ?? '',
+  email: user.value?.email ?? '',
+  subject: ''
+})
+const showEscalation = ref(false)
+const messagesContainer = ref<HTMLElement | null>(null)
+
+async function ensureSession() {
+  if (session.value) return
+  if (initialising.value) return
+  initialising.value = true
+  try {
+    const stored = sessionStorage.getItem(SESSION_KEY)
+    if (stored) {
+      const parsed = JSON.parse(stored) as { session: ChatbotSession, messages: ChatbotMessage[], shortcuts: FaqShortcut[] }
+      session.value = parsed.session
+      messages.value = parsed.messages
+      shortcuts.value = parsed.shortcuts
+      return
+    }
+    const result = await api<{ session: ChatbotSession, messages: ChatbotMessage[], faqShortcuts: FaqShortcut[] }>(
+      '/chatbot/sessions',
+      {
+        method: 'POST',
+        body: {
+          name: user.value?.fullName ?? undefined,
+          email: user.value?.email ?? undefined
+        }
+      }
+    )
+    session.value = result.session
+    messages.value = result.messages
+    shortcuts.value = result.faqShortcuts
+    persist()
+  } finally {
+    initialising.value = false
+  }
+}
+
+function persist() {
+  if (!session.value) return
+  sessionStorage.setItem(
+    SESSION_KEY,
+    JSON.stringify({ session: session.value, messages: messages.value, shortcuts: shortcuts.value })
+  )
+}
+
+async function toggle() {
+  open.value = !open.value
+  if (open.value) {
+    await ensureSession()
+    await nextTick()
+    scrollToBottom()
+  }
+}
+
+async function send(content: string) {
+  if (!session.value || sending.value || !content.trim()) return
+  sending.value = true
+  try {
+    const result = await api<{ messages: ChatbotMessage[], session?: ChatbotSession }>(
+      `/chatbot/sessions/${session.value.id}/messages`,
+      { method: 'POST', body: { content } }
+    )
+    messages.value = [...messages.value, ...result.messages]
+    if (result.session) session.value = result.session
+    persist()
+    if (session.value?.escalated && !session.value.visitorEmail) showEscalation.value = true
+    await nextTick()
+    scrollToBottom()
+  } catch (err) {
+    console.error(err)
+  } finally {
+    sending.value = false
+  }
+}
+
+async function submitDraft() {
+  const content = draft.value.trim()
+  if (!content) return
+  draft.value = ''
+  await send(content)
+}
+
+async function submitEscalation() {
+  if (!session.value || escalating.value) return
+  if (!/^.+@.+\..+$/.test(escalateForm.email)) return
+  escalating.value = true
+  try {
+    const result = await api<{ session: ChatbotSession, message: ChatbotMessage }>(
+      `/chatbot/sessions/${session.value.id}/escalate`,
+      {
+        method: 'POST',
+        body: {
+          name: escalateForm.name || undefined,
+          email: escalateForm.email,
+          subject: escalateForm.subject || undefined
+        }
+      }
+    )
+    session.value = result.session
+    messages.value = [...messages.value, result.message]
+    persist()
+    showEscalation.value = false
+    await nextTick()
+    scrollToBottom()
+  } finally {
+    escalating.value = false
+  }
+}
+
+function scrollToBottom() {
+  const el = messagesContainer.value
+  if (!el) return
+  el.scrollTop = el.scrollHeight
+}
+
+function reset() {
+  sessionStorage.removeItem(SESSION_KEY)
+  session.value = null
+  messages.value = []
+  shortcuts.value = []
+  showEscalation.value = false
+  ensureSession()
+}
+
+const SHORTCUT_QUERIES: Record<string, string> = {
+  'address-change': 'Comment changer mon adresse de livraison ?',
+  'payment-methods': 'Quels moyens de paiement acceptez-vous ?',
+  'shipping-delay': 'Quels sont les délais de livraison ?',
+  'return-policy': 'Comment retourner un produit ?',
+  'invoice': 'Où trouver mes factures ?',
+  'account': 'Comment créer un compte ?'
+}
+
+function quickAsk(intent: string) {
+  const q = SHORTCUT_QUERIES[intent] ?? intent
+  send(q)
+}
+</script>
+
+<template>
+  <div class="fixed bottom-4 right-4 z-50 flex flex-col items-end gap-3 md:bottom-6 md:right-6">
+    <Transition
+      enter-active-class="transition duration-200 ease-out"
+      enter-from-class="translate-y-2 opacity-0"
+      enter-to-class="translate-y-0 opacity-100"
+      leave-active-class="transition duration-150 ease-in"
+      leave-from-class="translate-y-0 opacity-100"
+      leave-to-class="translate-y-2 opacity-0"
+    >
+      <section
+        v-if="open"
+        class="flex w-[min(360px,calc(100vw-2rem))] flex-col overflow-hidden rounded-2xl border border-neutral-100 bg-white shadow-xl"
+        style="height: min(540px, calc(100vh - 6rem))"
+      >
+        <header class="flex items-center justify-between gap-3 border-b border-neutral-100 bg-brand-text px-4 py-3 text-white">
+          <div>
+            <p class="text-sm font-semibold">Assistant Althea</p>
+            <p class="text-xs opacity-80">{{ session?.escalated ? 'Conseiller mobilisé' : 'Réponses instantanées' }}</p>
+          </div>
+          <div class="flex items-center gap-1">
+            <button
+              v-if="session"
+              type="button"
+              class="rounded-md p-1 text-white/80 transition-colors hover:bg-white/10 hover:text-white"
+              aria-label="Réinitialiser"
+              @click="reset"
+            >
+              <svg viewBox="0 0 24 24" class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 12a9 9 0 1 0 3-6.7" stroke-linecap="round" stroke-linejoin="round"/><path d="M3 4v5h5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            </button>
+            <button
+              type="button"
+              class="rounded-md p-1 text-white/80 transition-colors hover:bg-white/10 hover:text-white"
+              aria-label="Fermer"
+              @click="open = false"
+            >
+              <svg viewBox="0 0 24 24" class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 6l12 12M6 18 18 6" stroke-linecap="round"/></svg>
+            </button>
+          </div>
+        </header>
+
+        <div ref="messagesContainer" class="flex-1 overflow-y-auto bg-brand-50/40 px-4 py-3">
+          <div v-for="msg in messages" :key="msg.id" class="mb-3 flex" :class="msg.role === 'user' ? 'justify-end' : 'justify-start'">
+            <div
+              class="max-w-[85%] whitespace-pre-line rounded-2xl px-3 py-2 text-sm shadow-sm"
+              :class="msg.role === 'user' ? 'bg-brand-500 text-white' : msg.role === 'agent' ? 'bg-amber-100 text-amber-900' : 'bg-white text-neutral-800'"
+            >
+              {{ msg.content }}
+            </div>
+          </div>
+
+          <div v-if="!session?.escalated && shortcuts.length" class="mt-2 flex flex-wrap gap-2">
+            <button
+              v-for="s in shortcuts"
+              :key="s.intent"
+              type="button"
+              class="rounded-full border border-brand-200 bg-white px-3 py-1 text-xs font-medium text-brand-text transition-colors hover:bg-brand-100"
+              @click="quickAsk(s.intent)"
+            >
+              {{ s.label }}
+            </button>
+          </div>
+        </div>
+
+        <div v-if="showEscalation" class="border-t border-neutral-100 bg-brand-50 px-4 py-3">
+          <p class="mb-2 text-xs font-semibold uppercase tracking-wide text-brand-text">Transmettre à un conseiller</p>
+          <div class="space-y-2">
+            <input
+              v-model="escalateForm.name"
+              type="text"
+              placeholder="Nom (optionnel)"
+              class="w-full rounded-md border border-neutral-200 px-2 py-1.5 text-sm outline-none focus:border-brand-400"
+            />
+            <input
+              v-model="escalateForm.email"
+              type="email"
+              placeholder="Email (requis)"
+              required
+              class="w-full rounded-md border border-neutral-200 px-2 py-1.5 text-sm outline-none focus:border-brand-400"
+            />
+            <input
+              v-model="escalateForm.subject"
+              type="text"
+              placeholder="Sujet (optionnel)"
+              class="w-full rounded-md border border-neutral-200 px-2 py-1.5 text-sm outline-none focus:border-brand-400"
+            />
+            <button
+              type="button"
+              :disabled="escalating"
+              class="w-full rounded-md bg-brand-500 px-3 py-1.5 text-sm font-semibold text-white transition-colors hover:bg-brand-600 disabled:opacity-60"
+              @click="submitEscalation"
+            >
+              {{ escalating ? 'Envoi...' : 'Envoyer au conseiller' }}
+            </button>
+          </div>
+        </div>
+
+        <form class="flex items-center gap-2 border-t border-neutral-100 bg-white px-3 py-2" @submit.prevent="submitDraft">
+          <input
+            v-model="draft"
+            type="text"
+            :disabled="sending || initialising"
+            placeholder="Posez votre question..."
+            class="flex-1 rounded-md border border-neutral-200 px-3 py-2 text-sm outline-none focus:border-brand-400"
+          />
+          <button
+            type="submit"
+            :disabled="sending || !draft.trim()"
+            class="rounded-md bg-brand-500 px-3 py-2 text-sm font-semibold text-white transition-colors hover:bg-brand-600 disabled:opacity-60"
+            aria-label="Envoyer"
+          >
+            <svg viewBox="0 0 24 24" class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 12 20 4l-7 16-2-7-7-1Z" stroke-linecap="round" stroke-linejoin="round"/></svg>
+          </button>
+        </form>
+      </section>
+    </Transition>
+
+    <button
+      type="button"
+      class="flex items-center gap-2 rounded-full bg-brand-500 px-4 py-3 text-sm font-semibold text-white shadow-lg transition-colors hover:bg-brand-600"
+      :aria-expanded="open"
+      @click="toggle"
+    >
+      <svg viewBox="0 0 24 24" class="h-5 w-5" fill="none" stroke="currentColor" stroke-width="2">
+        <path d="M21 11a8.5 8.5 0 0 1-12.5 7.5L3 21l1.6-4.5A8.5 8.5 0 1 1 21 11Z" stroke-linecap="round" stroke-linejoin="round"/>
+      </svg>
+      <span class="hidden sm:inline">{{ open ? 'Réduire' : 'Contactez-nous' }}</span>
+    </button>
+  </div>
+</template>

--- a/apps/storefront/app/layouts/default.vue
+++ b/apps/storefront/app/layouts/default.vue
@@ -11,6 +11,9 @@ const menuOpen = ref(false)
     </main>
     <AppFooter />
     <AppMobileMenu :open="menuOpen" @close="menuOpen = false" />
+    <ClientOnly>
+      <AppChatbot />
+    </ClientOnly>
     <AppToastHost />
   </div>
 </template>


### PR DESCRIPTION
Closes #36.

API: chatbot_sessions and chatbot_messages tables. POST /chatbot/sessions starts a session (binds the user when authenticated, otherwise stays anonymous), seeds a welcome message and returns FAQ shortcuts. POST /chatbot/sessions/:id/messages records the user input, runs it through a French keyword matcher covering 6 common topics (address change, payment methods, shipping delays, returns, invoices, account) and replies with a canned answer; the bot also detects escalation keywords (humain, agent, conseiller, support…) and flips the session to escalated. POST /chatbot/sessions/:id/escalate captures email/name/subject and marks the session for follow-up.

Storefront ships AppChatbot, a floating widget mounted in the default layout. The "Contactez-nous" button opens a chat window with the bot greeting, six FAQ chip shortcuts, a free-text input and a reset button. When the bot escalates, an inline form prompts for email + optional name/subject so the support team can pick up the conversation. Sessions persist in sessionStorage so reopening the widget within the tab keeps history.