### PR TITLE
feat(backoffice): messages and chatbot logs

### DIFF
--- a/apps/api/app/controllers/admin_messages_controller.ts
+++ b/apps/api/app/controllers/admin_messages_controller.ts
@@ -1,0 +1,104 @@
+import type { HttpContext } from '@adonisjs/core/http'
+import ContactMessage from '#models/contact_message'
+import ChatbotSession from '#models/chatbot_session'
+import ChatbotMessage from '#models/chatbot_message'
+import {
+  agentReplyValidator,
+  listChatSessionsValidator,
+  listMessagesValidator,
+} from '#validators/admin_messages'
+
+export default class AdminMessagesController {
+  async indexContact({ request }: HttpContext) {
+    const { q, status, page = 1, perPage = 25 } = await listMessagesValidator.validate(request.qs())
+    const builder = ContactMessage.query()
+    if (status === 'unread') builder.where('isRead', false)
+    else if (status === 'read') builder.where('isRead', true)
+    if (q) {
+      const pattern = `%${q}%`
+      builder.where((sub) => {
+        sub
+          .whereILike('email', pattern)
+          .orWhereILike('name', pattern)
+          .orWhereILike('subject', pattern)
+          .orWhereILike('message', pattern)
+      })
+    }
+    builder.orderBy('createdAt', 'desc')
+    const result = await builder.paginate(page, perPage)
+    return { meta: result.getMeta(), data: result.all() }
+  }
+
+  async showContact({ params }: HttpContext) {
+    const message = await ContactMessage.findOrFail(params.id)
+    if (!message.isRead) {
+      message.isRead = true
+      await message.save()
+    }
+    return message
+  }
+
+  async markContactRead({ params, request, response }: HttpContext) {
+    const message = await ContactMessage.findOrFail(params.id)
+    const isRead = request.input('isRead', true)
+    message.isRead = !!isRead
+    await message.save()
+    return response.noContent()
+  }
+
+  async indexChat({ request }: HttpContext) {
+    const { q, status, page = 1, perPage = 25 } = await listChatSessionsValidator.validate(
+      request.qs()
+    )
+    const builder = ChatbotSession.query().preload('user')
+    if (status === 'escalated') builder.where('escalated', true)
+    else if (status === 'unread') builder.where('isRead', false)
+    if (q) {
+      const pattern = `%${q}%`
+      builder.where((sub) => {
+        sub
+          .whereILike('visitorEmail', pattern)
+          .orWhereILike('visitorName', pattern)
+          .orWhereILike('subject', pattern)
+      })
+    }
+    builder.orderBy('createdAt', 'desc')
+    const result = await builder.paginate(page, perPage)
+    return {
+      meta: result.getMeta(),
+      data: result.all().map((session) => ({
+        ...session.serialize(),
+        identity:
+          session.visitorName || session.visitorEmail || session.user?.email || 'Visiteur anonyme',
+      })),
+    }
+  }
+
+  async showChat({ params }: HttpContext) {
+    const session = await ChatbotSession.query()
+      .where('id', params.id)
+      .preload('user')
+      .firstOrFail()
+    const messages = await ChatbotMessage.query()
+      .where('sessionId', session.id)
+      .orderBy('createdAt', 'asc')
+    if (!session.isRead) {
+      session.isRead = true
+      await session.save()
+    }
+    return { session, messages }
+  }
+
+  async replyChat({ params, request }: HttpContext) {
+    const session = await ChatbotSession.findOrFail(params.id)
+    const { content } = await request.validateUsing(agentReplyValidator)
+    const message = await ChatbotMessage.create({
+      sessionId: session.id,
+      role: 'agent',
+      content,
+    })
+    session.isRead = true
+    await session.save()
+    return { message, session }
+  }
+}

--- a/apps/api/app/validators/admin_messages.ts
+++ b/apps/api/app/validators/admin_messages.ts
@@ -1,0 +1,25 @@
+import vine from '@vinejs/vine'
+
+export const listMessagesValidator = vine.compile(
+  vine.object({
+    q: vine.string().trim().minLength(1).maxLength(120).optional(),
+    status: vine.enum(['all', 'unread', 'read'] as const).optional(),
+    page: vine.number().withoutDecimals().min(1).optional(),
+    perPage: vine.number().withoutDecimals().min(1).max(100).optional(),
+  })
+)
+
+export const listChatSessionsValidator = vine.compile(
+  vine.object({
+    q: vine.string().trim().minLength(1).maxLength(120).optional(),
+    status: vine.enum(['all', 'escalated', 'unread'] as const).optional(),
+    page: vine.number().withoutDecimals().min(1).optional(),
+    perPage: vine.number().withoutDecimals().min(1).max(100).optional(),
+  })
+)
+
+export const agentReplyValidator = vine.compile(
+  vine.object({
+    content: vine.string().trim().minLength(1).maxLength(4000),
+  })
+)

--- a/apps/api/start/routes.ts
+++ b/apps/api/start/routes.ts
@@ -21,6 +21,7 @@ const AdminHomepageController = () => import('#controllers/admin_homepage_contro
 const AdminUsersController = () => import('#controllers/admin_users_controller')
 const AdminOrdersController = () => import('#controllers/admin_orders_controller')
 const AdminInvoicesController = () => import('#controllers/admin_invoices_controller')
+const AdminMessagesController = () => import('#controllers/admin_messages_controller')
 
 router.get('/', async () => ({ hello: 'world' }))
 
@@ -134,6 +135,12 @@ router
     router.get('credit-notes', [AdminInvoicesController, 'indexCreditNotes'])
     router.get('credit-notes/:id/download', [AdminInvoicesController, 'downloadCreditNote'])
     router.post('credit-notes/:id/resend', [AdminInvoicesController, 'resendCreditNote'])
+    router.get('messages', [AdminMessagesController, 'indexContact'])
+    router.get('messages/:id', [AdminMessagesController, 'showContact'])
+    router.patch('messages/:id/read', [AdminMessagesController, 'markContactRead'])
+    router.get('chatbot/sessions', [AdminMessagesController, 'indexChat'])
+    router.get('chatbot/sessions/:id', [AdminMessagesController, 'showChat'])
+    router.post('chatbot/sessions/:id/reply', [AdminMessagesController, 'replyChat'])
   })
   .prefix('/admin')
   .use([middleware.auth(), middleware.admin()])

--- a/apps/backoffice/app/composables/useApiTypes.ts
+++ b/apps/backoffice/app/composables/useApiTypes.ts
@@ -111,6 +111,40 @@ export interface AdminUserDetail {
   totalRevenue: number
 }
 
+export interface AdminContactMessage {
+  id: number
+  userId: number | null
+  name: string
+  email: string
+  subject: string
+  message: string
+  isRead: boolean
+  createdAt: string
+}
+
+export interface AdminChatbotSession {
+  id: number
+  userId: number | null
+  visitorName: string | null
+  visitorEmail: string | null
+  subject: string | null
+  escalated: boolean
+  escalatedAt: string | null
+  isRead: boolean
+  createdAt: string
+  identity?: string
+  user?: { id: number, email: string, fullName: string | null } | null
+}
+
+export interface AdminChatbotMessage {
+  id: number
+  sessionId: number
+  role: 'user' | 'bot' | 'agent'
+  content: string
+  intent: string | null
+  createdAt: string
+}
+
 export interface AdminInvoice {
   id: number
   invoiceNumber: string

--- a/apps/backoffice/app/layouts/default.vue
+++ b/apps/backoffice/app/layouts/default.vue
@@ -10,6 +10,7 @@ const navItems = [
   { label: 'Carrousel', icon: 'i-lucide-images', to: '/homepage' },
   { label: 'Commandes', icon: 'i-lucide-shopping-bag', to: '/orders' },
   { label: 'Factures', icon: 'i-lucide-file-text', to: '/invoices' },
+  { label: 'Messages', icon: 'i-lucide-message-circle', to: '/messages' },
   { label: 'Utilisateurs', icon: 'i-lucide-users', to: '/users' },
   { label: 'Sécurité', icon: 'i-lucide-shield-check', to: '/security' }
 ]

--- a/apps/backoffice/app/pages/messages.vue
+++ b/apps/backoffice/app/pages/messages.vue
@@ -1,0 +1,288 @@
+<script setup lang="ts">
+import type {
+  AdminChatbotMessage,
+  AdminChatbotSession,
+  AdminContactMessage,
+  Paginated
+} from '~/composables/useApiTypes'
+
+const api = useApi()
+const { dateTime } = useFormat()
+const toast = useToast()
+
+const tab = ref<'contact' | 'chatbot'>('contact')
+
+const contactStatus = ref<'all' | 'unread' | 'read'>('all')
+const contactSearch = ref('')
+const debouncedContactSearch = ref('')
+let contactDebounce: ReturnType<typeof setTimeout> | undefined
+watch(contactSearch, (value) => {
+  if (contactDebounce) clearTimeout(contactDebounce)
+  contactDebounce = setTimeout(() => { debouncedContactSearch.value = value }, 300)
+})
+
+const contactParams = computed(() => {
+  const params: Record<string, string> = { status: contactStatus.value }
+  if (debouncedContactSearch.value) params.q = debouncedContactSearch.value
+  return params
+})
+const { data: contacts, refresh: refreshContacts } = await useAsyncData<Paginated<AdminContactMessage>>(
+  'admin-contacts',
+  () => api<Paginated<AdminContactMessage>>('/admin/messages', { params: contactParams.value }),
+  { watch: [contactParams] }
+)
+
+const chatStatus = ref<'all' | 'escalated' | 'unread'>('all')
+const chatSearch = ref('')
+const debouncedChatSearch = ref('')
+let chatDebounce: ReturnType<typeof setTimeout> | undefined
+watch(chatSearch, (value) => {
+  if (chatDebounce) clearTimeout(chatDebounce)
+  chatDebounce = setTimeout(() => { debouncedChatSearch.value = value }, 300)
+})
+
+const chatParams = computed(() => {
+  const params: Record<string, string> = { status: chatStatus.value }
+  if (debouncedChatSearch.value) params.q = debouncedChatSearch.value
+  return params
+})
+const { data: chats, refresh: refreshChats } = await useAsyncData<Paginated<AdminChatbotSession>>(
+  'admin-chats',
+  () => api<Paginated<AdminChatbotSession>>('/admin/chatbot/sessions', { params: chatParams.value }),
+  { watch: [chatParams] }
+)
+
+const selectedContact = ref<AdminContactMessage | null>(null)
+const selectedChat = ref<AdminChatbotSession | null>(null)
+const chatTranscript = ref<AdminChatbotMessage[]>([])
+const replyDraft = ref('')
+const replying = ref(false)
+
+const contactOpen = computed({
+  get: () => selectedContact.value !== null,
+  set: (v: boolean) => { if (!v) selectedContact.value = null }
+})
+const chatOpen = computed({
+  get: () => selectedChat.value !== null,
+  set: (v: boolean) => { if (!v) { selectedChat.value = null; chatTranscript.value = [] } }
+})
+
+async function openContact(message: AdminContactMessage) {
+  const fresh = await api<AdminContactMessage>(`/admin/messages/${message.id}`)
+  selectedContact.value = fresh
+  refreshContacts()
+}
+
+async function openChat(session: AdminChatbotSession) {
+  const detail = await api<{ session: AdminChatbotSession, messages: AdminChatbotMessage[] }>(
+    `/admin/chatbot/sessions/${session.id}`
+  )
+  selectedChat.value = detail.session
+  chatTranscript.value = detail.messages
+  refreshChats()
+}
+
+async function toggleContactRead(message: AdminContactMessage) {
+  await api(`/admin/messages/${message.id}/read`, { method: 'PATCH', body: { isRead: !message.isRead } })
+  refreshContacts()
+}
+
+async function sendReply() {
+  if (!selectedChat.value || !replyDraft.value.trim()) return
+  replying.value = true
+  try {
+    const result = await api<{ message: AdminChatbotMessage }>(
+      `/admin/chatbot/sessions/${selectedChat.value.id}/reply`,
+      { method: 'POST', body: { content: replyDraft.value } }
+    )
+    chatTranscript.value = [...chatTranscript.value, result.message]
+    replyDraft.value = ''
+    toast.add({ color: 'success', title: 'Réponse envoyée.' })
+  } catch (err) {
+    toast.add({ color: 'error', title: extractMessage(err, 'Envoi impossible.') })
+  } finally {
+    replying.value = false
+  }
+}
+
+const contactStatusItems = [
+  { label: 'Toutes', value: 'all' as const },
+  { label: 'Non lues', value: 'unread' as const },
+  { label: 'Lues', value: 'read' as const }
+]
+
+const chatStatusItems = [
+  { label: 'Toutes', value: 'all' as const },
+  { label: 'Escaladées', value: 'escalated' as const },
+  { label: 'Non lues', value: 'unread' as const }
+]
+
+const roleColor: Record<string, 'primary' | 'success' | 'warning' | 'neutral'> = {
+  user: 'primary',
+  bot: 'neutral',
+  agent: 'success'
+}
+
+const roleLabel: Record<string, string> = {
+  user: 'Visiteur',
+  bot: 'Bot',
+  agent: 'Conseiller'
+}
+
+function extractMessage(err: unknown, fallback: string) {
+  if (err && typeof err === 'object' && 'data' in err) {
+    const data = (err as { data?: { message?: string } }).data
+    if (data?.message) return data.message
+  }
+  return fallback
+}
+</script>
+
+<template>
+  <UDashboardNavbar title="Messages" />
+  <div class="flex flex-col gap-4 sm:gap-6 flex-1 overflow-y-auto p-4 sm:p-6">
+    <UCard>
+      <template #header>
+        <UTabs
+          v-model="tab"
+          :items="[
+            { label: `Formulaire (${contacts?.meta?.total ?? 0})`, value: 'contact' },
+            { label: `Chatbot (${chats?.meta?.total ?? 0})`, value: 'chatbot' }
+          ]"
+        />
+      </template>
+
+      <div v-if="tab === 'contact'">
+        <div class="mb-4 flex flex-wrap items-center gap-3">
+          <UInput v-model="contactSearch" icon="i-lucide-search" placeholder="Email, sujet, contenu..." class="w-72" />
+          <USelect v-model="contactStatus" :items="contactStatusItems" class="w-40" />
+        </div>
+        <div v-if="!contacts?.data?.length" class="py-12 text-center text-sm text-muted">Aucun message.</div>
+        <ul v-else class="divide-y divide-default">
+          <li
+            v-for="msg in contacts.data"
+            :key="msg.id"
+            class="flex cursor-pointer items-start gap-3 py-3 first:pt-0 last:pb-0 hover:bg-elevated/50 -mx-2 px-2 rounded-md"
+            @click="openContact(msg)"
+          >
+            <UIcon :name="msg.isRead ? 'i-lucide-mail-open' : 'i-lucide-mail'" class="size-4 mt-1" :class="msg.isRead ? 'text-muted' : 'text-primary'" />
+            <div class="flex-1 min-w-0">
+              <div class="flex items-center justify-between gap-3">
+                <p class="font-medium" :class="msg.isRead ? '' : 'text-primary'">{{ msg.subject }}</p>
+                <span class="text-xs text-muted shrink-0">{{ dateTime(msg.createdAt) }}</span>
+              </div>
+              <p class="text-sm text-muted">{{ msg.name }} · {{ msg.email }}</p>
+              <p class="text-sm line-clamp-1">{{ msg.message }}</p>
+            </div>
+          </li>
+        </ul>
+      </div>
+
+      <div v-else>
+        <div class="mb-4 flex flex-wrap items-center gap-3">
+          <UInput v-model="chatSearch" icon="i-lucide-search" placeholder="Email, nom, sujet..." class="w-72" />
+          <USelect v-model="chatStatus" :items="chatStatusItems" class="w-48" />
+        </div>
+        <div v-if="!chats?.data?.length" class="py-12 text-center text-sm text-muted">Aucune conversation.</div>
+        <ul v-else class="divide-y divide-default">
+          <li
+            v-for="session in chats.data"
+            :key="session.id"
+            class="flex cursor-pointer items-start gap-3 py-3 first:pt-0 last:pb-0 hover:bg-elevated/50 -mx-2 px-2 rounded-md"
+            @click="openChat(session)"
+          >
+            <UIcon name="i-lucide-message-square" class="size-4 mt-1" :class="session.isRead ? 'text-muted' : 'text-primary'" />
+            <div class="flex-1 min-w-0">
+              <div class="flex items-center justify-between gap-3">
+                <p class="font-medium">{{ session.identity }}</p>
+                <span class="text-xs text-muted shrink-0">{{ dateTime(session.createdAt) }}</span>
+              </div>
+              <p class="text-sm text-muted">{{ session.subject || 'Conversation chatbot' }}</p>
+              <div class="mt-1 flex items-center gap-2">
+                <UBadge v-if="session.escalated" color="warning" variant="subtle">Escaladée</UBadge>
+                <UBadge v-if="!session.isRead" color="primary" variant="subtle">Non lu</UBadge>
+              </div>
+            </div>
+          </li>
+        </ul>
+      </div>
+    </UCard>
+
+    <USlideover v-model:open="contactOpen" :ui="{ content: 'w-full md:max-w-xl' }">
+      <template #content>
+        <div class="flex h-full flex-col">
+          <div class="border-b border-default p-4">
+            <h2 class="font-semibold text-lg">{{ selectedContact?.subject }}</h2>
+            <p class="text-sm text-muted">{{ selectedContact?.name }} · {{ selectedContact?.email }}</p>
+            <p class="text-xs text-muted">{{ selectedContact ? dateTime(selectedContact.createdAt) : '' }}</p>
+          </div>
+          <div class="flex-1 overflow-y-auto p-4 whitespace-pre-line text-sm">
+            {{ selectedContact?.message }}
+          </div>
+          <div class="border-t border-default p-4 flex justify-between items-center">
+            <UButton
+              :icon="selectedContact?.isRead ? 'i-lucide-mail' : 'i-lucide-mail-open'"
+              variant="ghost"
+              color="neutral"
+              :label="selectedContact?.isRead ? 'Marquer non lu' : 'Marquer lu'"
+              :disabled="!selectedContact"
+              @click="selectedContact && toggleContactRead(selectedContact)"
+            />
+            <UButton
+              v-if="selectedContact"
+              :to="`mailto:${selectedContact.email}?subject=Re: ${encodeURIComponent(selectedContact.subject)}`"
+              icon="i-lucide-reply"
+              color="primary"
+              label="Répondre par email"
+            />
+          </div>
+        </div>
+      </template>
+    </USlideover>
+
+    <USlideover v-model:open="chatOpen" :ui="{ content: 'w-full md:max-w-2xl' }">
+      <template #content>
+        <div class="flex h-full flex-col">
+          <div class="border-b border-default p-4">
+            <h2 class="font-semibold text-lg">{{ selectedChat?.identity || selectedChat?.visitorEmail || 'Conversation' }}</h2>
+            <p class="text-sm text-muted">
+              {{ selectedChat?.subject || 'Conversation chatbot' }} ·
+              {{ selectedChat ? dateTime(selectedChat.createdAt) : '' }}
+            </p>
+            <div class="mt-2 flex items-center gap-2">
+              <UBadge v-if="selectedChat?.escalated" color="warning" variant="subtle">Escaladée</UBadge>
+              <UBadge v-if="selectedChat?.visitorEmail" color="primary" variant="subtle">{{ selectedChat.visitorEmail }}</UBadge>
+            </div>
+          </div>
+          <div class="flex-1 overflow-y-auto p-4 space-y-3">
+            <div
+              v-for="msg in chatTranscript"
+              :key="msg.id"
+              class="flex"
+              :class="msg.role === 'user' ? 'justify-end' : 'justify-start'"
+            >
+              <div class="max-w-[85%]">
+                <p class="text-xs text-muted mb-1" :class="msg.role === 'user' ? 'text-right' : ''">
+                  <UBadge :color="roleColor[msg.role] ?? 'neutral'" variant="subtle" size="sm">{{ roleLabel[msg.role] ?? msg.role }}</UBadge>
+                  <span class="ml-2">{{ dateTime(msg.createdAt) }}</span>
+                </p>
+                <div
+                  class="whitespace-pre-line rounded-2xl px-3 py-2 text-sm shadow-sm"
+                  :class="msg.role === 'user' ? 'bg-primary text-inverted' : msg.role === 'agent' ? 'bg-warning/10' : 'bg-elevated'"
+                >
+                  {{ msg.content }}
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="border-t border-default p-4">
+            <UTextarea v-model="replyDraft" :rows="3" placeholder="Réponse du conseiller..." class="w-full" />
+            <div class="mt-2 flex justify-end gap-2">
+              <UButton :loading="replying" :disabled="!replyDraft.trim()" icon="i-lucide-send" label="Répondre" @click="sendReply" />
+            </div>
+          </div>
+        </div>
+      </template>
+    </USlideover>
+  </div>
+</template>


### PR DESCRIPTION
Closes #37.

API exposes /admin/messages and /admin/chatbot/sessions for the support team. Contact messages are listed with search across email, name, subject and body plus a read/unread filter; opening a message marks it as read and a toggle lets the team flip the state back. Chatbot sessions list with search across visitor name/email/subject and an escalated/unread filter; the detail endpoint returns the full message transcript and POST /reply lets a conseiller post an agent message into the same conversation.

Backoffice ships /messages, a tabbed UCard switching between contact form messages and chatbot conversations. Each row opens a slide-over: the contact pane shows full message + a mailto reply link and a read/unread toggle, the chatbot pane shows the bubble transcript with role badges and a textarea to send an agent reply that lands in the storefront chat session. Sidebar gets a new Messages entry.