### PR TITLE
feat(storefront): paginate product lists

### DIFF
--- a/apps/storefront/app/components/AppPagination.vue
+++ b/apps/storefront/app/components/AppPagination.vue
@@ -1,0 +1,76 @@
+<script setup lang="ts">
+interface Props {
+  currentPage: number
+  lastPage: number
+  total: number
+  perPage: number
+  windowSize?: number
+}
+
+const props = withDefaults(defineProps<Props>(), { windowSize: 5 })
+const emit = defineEmits<{ 'update:page': [number] }>()
+
+const pages = computed<number[]>(() => {
+  if (props.lastPage <= 1) return [1]
+  const half = Math.floor(props.windowSize / 2)
+  let start = Math.max(1, props.currentPage - half)
+  let end = Math.min(props.lastPage, start + props.windowSize - 1)
+  if (end - start + 1 < props.windowSize) start = Math.max(1, end - props.windowSize + 1)
+  const list: number[] = []
+  for (let p = start; p <= end; p++) list.push(p)
+  return list
+})
+
+const rangeStart = computed(() => (props.currentPage - 1) * props.perPage + 1)
+const rangeEnd = computed(() => Math.min(props.currentPage * props.perPage, props.total))
+
+function go(page: number) {
+  if (page < 1 || page > props.lastPage || page === props.currentPage) return
+  emit('update:page', page)
+}
+</script>
+
+<template>
+  <nav v-if="lastPage > 1" class="flex items-center justify-between gap-3" aria-label="Pagination">
+    <p class="text-sm text-neutral-600">
+      {{ rangeStart }}–{{ rangeEnd }} sur {{ total }}
+    </p>
+    <ul class="flex items-center gap-1">
+      <li>
+        <button
+          type="button"
+          class="flex h-9 w-9 items-center justify-center rounded-md border border-neutral-200 text-sm text-neutral-700 transition-colors hover:border-brand-500 hover:text-brand-500 disabled:cursor-not-allowed disabled:opacity-40"
+          :disabled="currentPage <= 1"
+          aria-label="Page précédente"
+          @click="go(currentPage - 1)"
+        >
+          <svg viewBox="0 0 24 24" class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2"><path d="m15 18-6-6 6-6" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        </button>
+      </li>
+      <li v-for="page in pages" :key="page">
+        <button
+          type="button"
+          class="flex h-9 min-w-9 items-center justify-center rounded-md border px-2 text-sm transition-colors"
+          :class="page === currentPage
+            ? 'border-brand-500 bg-brand-500 text-white'
+            : 'border-neutral-200 text-neutral-700 hover:border-brand-500 hover:text-brand-500'"
+          :aria-current="page === currentPage ? 'page' : undefined"
+          @click="go(page)"
+        >
+          {{ page }}
+        </button>
+      </li>
+      <li>
+        <button
+          type="button"
+          class="flex h-9 w-9 items-center justify-center rounded-md border border-neutral-200 text-sm text-neutral-700 transition-colors hover:border-brand-500 hover:text-brand-500 disabled:cursor-not-allowed disabled:opacity-40"
+          :disabled="currentPage >= lastPage"
+          aria-label="Page suivante"
+          @click="go(currentPage + 1)"
+        >
+          <svg viewBox="0 0 24 24" class="h-4 w-4" fill="none" stroke="currentColor" stroke-width="2"><path d="m9 6 6 6-6 6" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        </button>
+      </li>
+    </ul>
+  </nav>
+</template>

--- a/apps/storefront/app/pages/categories/[slug].vue
+++ b/apps/storefront/app/pages/categories/[slug].vue
@@ -22,6 +22,10 @@ const sortOptions: SortOption[] = [
 
 const selectedSort = ref('priority-desc')
 const inStockOnly = ref(false)
+const page = ref(1)
+const PER_PAGE = 24
+
+watch([selectedSort, inStockOnly], () => { page.value = 1 })
 
 const productParams = computed(() => {
   const option = sortOptions.find((o) => o.value === selectedSort.value)!
@@ -30,9 +34,15 @@ const productParams = computed(() => {
     sort: option.sort,
     order: option.order,
     inStockOnly: inStockOnly.value || undefined,
-    perPage: 24,
+    perPage: PER_PAGE,
+    page: page.value,
   }
 })
+
+function changePage(next: number) {
+  page.value = next
+  if (import.meta.client) window.scrollTo({ top: 0, behavior: 'smooth' })
+}
 
 const { data: productsResult } = await useProducts(productParams)
 const products = computed(() => productsResult.value?.data ?? [])
@@ -75,6 +85,16 @@ const isMobile = useMediaQuery()
 
       <div class="mt-8">
         <AppProductGrid :products="products" :layout="isMobile ? 'list' : 'grid'" />
+      </div>
+
+      <div v-if="productsResult?.meta && productsResult.meta.lastPage > 1" class="mt-8">
+        <AppPagination
+          :current-page="productsResult.meta.currentPage"
+          :last-page="productsResult.meta.lastPage"
+          :total="productsResult.meta.total"
+          :per-page="productsResult.meta.perPage"
+          @update:page="changePage"
+        />
       </div>
     </section>
   </div>

--- a/apps/storefront/app/pages/search.vue
+++ b/apps/storefront/app/pages/search.vue
@@ -25,6 +25,17 @@ const categoryId = ref<number | undefined>(
 )
 const inStockOnly = ref(route.query.inStockOnly === '1')
 const selectedSort = ref(String(route.query.sort ?? 'relevance-desc'))
+const page = ref(route.query.page ? Number(route.query.page) : 1)
+const PER_PAGE = 24
+
+watch([query, minPrice, maxPrice, categoryId, inStockOnly, selectedSort], () => {
+  page.value = 1
+})
+
+function changePage(next: number) {
+  page.value = next
+  if (import.meta.client) window.scrollTo({ top: 0, behavior: 'smooth' })
+}
 
 const { data: categoriesResult } = await useCategories()
 const categories = computed(() => categoriesResult.value ?? [])
@@ -39,7 +50,8 @@ const productParams = computed(() => {
     inStockOnly: inStockOnly.value || undefined,
     sort: option.sort,
     order: option.order,
-    perPage: 24,
+    perPage: PER_PAGE,
+    page: page.value,
   }
 })
 
@@ -57,6 +69,7 @@ watchDebounced(
         maxPrice: maxPrice.value,
         inStockOnly: inStockOnly.value ? '1' : undefined,
         sort: selectedSort.value,
+        page: page.value > 1 ? page.value : undefined,
       },
     })
   },
@@ -174,6 +187,16 @@ function clearFilters() {
           <AppProductGrid
             :products="products"
             empty-message="Aucun produit ne correspond à vos critères."
+          />
+        </div>
+
+        <div v-if="productsResult?.meta && productsResult.meta.lastPage > 1" class="mt-8">
+          <AppPagination
+            :current-page="productsResult.meta.currentPage"
+            :last-page="productsResult.meta.lastPage"
+            :total="productsResult.meta.total"
+            :per-page="productsResult.meta.perPage"
+            @update:page="changePage"
           />
         </div>
       </div>


### PR DESCRIPTION
Closes #40.

Adds AppPagination, a numbered pager with prev/next arrows, range summary and a sliding window around the current page. Wires it on category pages (/categories/:slug) and the search page (/search). Page state resets on filter/sort changes; on /search the page is also reflected in the URL so the back button restores position.