### PR TITLE
feat(storefront): accessibility improvements

### DIFF
--- a/apps/storefront/app/layouts/default.vue
+++ b/apps/storefront/app/layouts/default.vue
@@ -1,12 +1,19 @@
 <script setup lang="ts">
 const menuOpen = ref(false)
+const { t } = useI18n()
 </script>
 
 <template>
   <div class="flex min-h-screen flex-col bg-white text-neutral-800">
+    <a
+      href="#main-content"
+      class="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-[80] focus:rounded-md focus:bg-brand-500 focus:px-4 focus:py-2 focus:text-sm focus:font-semibold focus:text-white"
+    >
+      {{ t('nav.skip_to_content') }}
+    </a>
     <AppLoadingBar />
     <AppHeader @open-menu="menuOpen = true" />
-    <main class="flex-1">
+    <main id="main-content" class="flex-1" tabindex="-1">
       <slot />
     </main>
     <AppFooter />

--- a/apps/storefront/assets/css/main.css
+++ b/apps/storefront/assets/css/main.css
@@ -1,5 +1,11 @@
 @import "tailwindcss";
 
+:focus-visible {
+  outline: 2px solid var(--color-brand-500);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
 @theme {
   --color-brand-50: #d4f4f7;
   --color-brand-300: #33bfc9;


### PR DESCRIPTION
Closes #39.

Adds a translated skip-to-content link that appears on focus, gives main a tabindex/-1 anchor, and a global :focus-visible outline so keyboard users can always tell where focus sits. Header and footer aria-labels were already i18n-aware after the previous PR; product/category images already carry alt text and existing modals/menus already trap focus through their underlying components.

Remaining a11y polish (audited but already in place): all icon-only buttons in header/chatbot/menu carry aria-labels, color contrast on the brand palette meets WCAG AA, form fields use real `<label>` elements, and Nuxt UI components in the backoffice expose proper roles by default.