### PR TITLE
fix(storefront): missing skip_to_content i18n key

### DIFF
--- a/apps/storefront/i18n/locales/ar.json
+++ b/apps/storefront/i18n/locales/ar.json
@@ -6,7 +6,8 @@
     "account": "حسابي",
     "language": "تغيير اللغة",
     "open_menu": "فتح القائمة",
-    "close": "إغلاق"
+    "close": "إغلاق",
+    "skip_to_content": "الانتقال إلى المحتوى الرئيسي"
   },
   "footer": {
     "rights": "© {year} Althea Systems",

--- a/apps/storefront/i18n/locales/en.json
+++ b/apps/storefront/i18n/locales/en.json
@@ -6,7 +6,8 @@
     "account": "My account",
     "language": "Change language",
     "open_menu": "Open menu",
-    "close": "Close"
+    "close": "Close",
+    "skip_to_content": "Skip to main content"
   },
   "footer": {
     "rights": "© {year} Althea Systems",

--- a/apps/storefront/i18n/locales/fr.json
+++ b/apps/storefront/i18n/locales/fr.json
@@ -6,7 +6,8 @@
     "account": "Mon compte",
     "language": "Changer la langue",
     "open_menu": "Ouvrir le menu",
-    "close": "Fermer"
+    "close": "Fermer",
+    "skip_to_content": "Aller au contenu principal"
   },
   "footer": {
     "rights": "© {year} Althea Systems",


### PR DESCRIPTION
Adds nav.skip_to_content to fr/en/ar so the skip link merged in #77 actually renders.