### PR TITLE
docs: M8 deliverables (openapi, architecture, install, deploy, security, tests, ci)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,58 @@
+name: CI
+
+on:
+  push:
+    branches: [main, development]
+  pull_request:
+    branches: [main, development]
+
+jobs:
+  api:
+    name: API · typecheck + tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter api typecheck
+      - run: pnpm --filter api test
+
+  storefront:
+    name: Storefront · build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter storefront build
+        env:
+          NUXT_PUBLIC_API_BASE: http://localhost:3333
+          NUXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: pk_test_dummy
+
+  backoffice:
+    name: Backoffice · typecheck + build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm --filter backoffice typecheck
+      - run: pnpm --filter backoffice build

--- a/apps/api/start/routes.ts
+++ b/apps/api/start/routes.ts
@@ -1,4 +1,7 @@
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
 import router from '@adonisjs/core/services/router'
+import app from '@adonisjs/core/services/app'
 import { middleware } from './kernel.js'
 
 const AuthController = () => import('#controllers/auth_controller')
@@ -24,6 +27,38 @@ const AdminInvoicesController = () => import('#controllers/admin_invoices_contro
 const AdminMessagesController = () => import('#controllers/admin_messages_controller')
 
 router.get('/', async () => ({ hello: 'world' }))
+
+router.get('/openapi.yaml', async ({ response }) => {
+  const file = path.join(app.makePath('..', '..', 'docs'), 'openapi.yaml')
+  const yaml = await readFile(file, 'utf8')
+  response.header('Content-Type', 'application/yaml')
+  return yaml
+})
+
+router.get('/docs', async ({ response }) => {
+  response.header('Content-Type', 'text/html')
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Althea API · Swagger UI</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui.css" />
+  <style>body { margin: 0 }</style>
+</head>
+<body>
+  <div id="swagger"></div>
+  <script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-bundle.js"></script>
+  <script>
+    window.ui = SwaggerUIBundle({
+      url: '/openapi.yaml',
+      dom_id: '#swagger',
+      deepLinking: true,
+      presets: [SwaggerUIBundle.presets.apis]
+    })
+  </script>
+</body>
+</html>`
+})
 
 router.get('/site-config/homepage', [SiteConfigController, 'homepage'])
 

--- a/apps/api/tests/functional/health.spec.ts
+++ b/apps/api/tests/functional/health.spec.ts
@@ -1,0 +1,21 @@
+import { test } from '@japa/runner'
+
+test.group('health and docs', () => {
+  test('GET / returns the hello payload', async ({ client }) => {
+    const response = await client.get('/')
+    response.assertStatus(200)
+    response.assertBodyContains({ hello: 'world' })
+  })
+
+  test('GET /docs serves Swagger UI', async ({ client }) => {
+    const response = await client.get('/docs')
+    response.assertStatus(200)
+    response.assertTextIncludes('SwaggerUIBundle')
+  })
+
+  test('GET /openapi.yaml returns the spec', async ({ client }) => {
+    const response = await client.get('/openapi.yaml')
+    response.assertStatus(200)
+    response.assertTextIncludes('openapi: 3.1.0')
+  })
+})

--- a/apps/api/tests/unit/chatbot_brain.spec.ts
+++ b/apps/api/tests/unit/chatbot_brain.spec.ts
@@ -1,0 +1,33 @@
+import { test } from '@japa/runner'
+import { reply, welcomeMessage } from '#services/chatbot_brain'
+
+test.group('chatbot brain', () => {
+  test('matches the address-change FAQ', ({ assert }) => {
+    const result = reply('Comment changer mon adresse ?')
+    assert.equal(result.intent, 'address-change')
+    assert.isFalse(result.shouldEscalate)
+  })
+
+  test('matches the payment FAQ', ({ assert }) => {
+    const result = reply('Quels sont les moyens de paiement ?')
+    assert.equal(result.intent, 'payment-methods')
+  })
+
+  test('escalates when the visitor asks for an agent', ({ assert }) => {
+    const result = reply('Je veux parler à un humain')
+    assert.equal(result.intent, 'escalate')
+    assert.isTrue(result.shouldEscalate)
+  })
+
+  test('falls back when nothing matches', ({ assert }) => {
+    const result = reply('Question complètement hors sujet')
+    assert.equal(result.intent, 'fallback')
+    assert.isFalse(result.shouldEscalate)
+  })
+
+  test('welcome message lists FAQ topics', ({ assert }) => {
+    const message = welcomeMessage()
+    assert.match(message, /assistant Althea/)
+    assert.match(message, /paiement|adresse|livraison/i)
+  })
+})

--- a/apps/api/tests/unit/totp_service.spec.ts
+++ b/apps/api/tests/unit/totp_service.spec.ts
@@ -1,0 +1,43 @@
+import { test } from '@japa/runner'
+import { authenticator } from 'otplib'
+import {
+  buildOtpAuthUrl,
+  consumeRecoveryCode,
+  generateRecoveryCodes,
+  generateTotpSecret,
+  hashRecoveryCode,
+  verifyTotpCode,
+} from '#services/totp_service'
+
+test.group('totp service', () => {
+  test('generates a base32 secret', ({ assert }) => {
+    const secret = generateTotpSecret()
+    assert.match(secret, /^[A-Z2-7]+$/)
+  })
+
+  test('builds an otpauth url with the issuer and email', ({ assert }) => {
+    const url = buildOtpAuthUrl('admin@althea.local', 'JBSWY3DPEHPK3PXP')
+    assert.include(url, 'otpauth://totp/')
+    assert.include(url, 'admin%40althea.local')
+    assert.include(url, 'JBSWY3DPEHPK3PXP')
+  })
+
+  test('verifies a valid TOTP code', ({ assert }) => {
+    const secret = 'JBSWY3DPEHPK3PXP'
+    const code = authenticator.generate(secret)
+    assert.isTrue(verifyTotpCode(secret, code))
+  })
+
+  test('rejects an invalid code', ({ assert }) => {
+    assert.isFalse(verifyTotpCode('JBSWY3DPEHPK3PXP', '000000'))
+  })
+
+  test('consumes a recovery code exactly once', ({ assert }) => {
+    const codes = generateRecoveryCodes(3)
+    const hashes = codes.map(hashRecoveryCode)
+    const remaining = consumeRecoveryCode(hashes, codes[0]!)
+    assert.isNotNull(remaining)
+    assert.lengthOf(remaining!, 2)
+    assert.isNull(consumeRecoveryCode(remaining!, codes[0]!))
+  })
+})

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,180 @@
+# Althea Systems — Architecture (DCT)
+
+This document captures the technical architecture of the Althea Systems platform: the
+three Nuxt/Adonis applications that make up the system, how they communicate, where data
+lives, and the rationale behind each technology choice.
+
+## 1. High-level architecture
+
+```mermaid
+flowchart LR
+  subgraph Clients
+    BR[Browser - Storefront]
+    BO[Browser - Backoffice]
+  end
+
+  subgraph Storefront [apps/storefront · Nuxt 4 + Tailwind v4]
+    SF[Server-side rendering / hydration]
+  end
+
+  subgraph Backoffice [apps/backoffice · Nuxt 4 + Nuxt UI v4]
+    BOA[SPA admin console]
+  end
+
+  subgraph API [apps/api · AdonisJS 6]
+    AC[REST controllers]
+    AS[Services - cart pricing, totp, mailers, invoice/credit-note PDF]
+    AM[Lucid models]
+  end
+
+  subgraph Data
+    PG[(PostgreSQL)]
+    MG[(MongoDB GridFS · product images)]
+    FS[(Local storage · invoice + credit-note PDFs)]
+  end
+
+  subgraph External
+    ST[Stripe · payments + customers]
+    SMTP[SMTP / log mailer]
+  end
+
+  BR -->|HTTPS / Bearer token| SF
+  BO -->|HTTPS / Bearer token| BOA
+  SF -->|REST + Bearer| AC
+  BOA -->|REST + Bearer| AC
+  AC --> AS
+  AS --> AM
+  AM --> PG
+  AS --> MG
+  AS --> FS
+  AS --> ST
+  AS --> SMTP
+```
+
+## 2. Data flow — checkout
+
+```mermaid
+sequenceDiagram
+  participant U as Customer
+  participant SF as Storefront (Nuxt)
+  participant API as API (Adonis)
+  participant DB as PostgreSQL
+  participant ST as Stripe
+
+  U->>SF: Add to cart, open checkout
+  SF->>API: POST /checkout/quote (cart lines)
+  API->>DB: Validate stock + prices
+  API-->>SF: Quote (subtotal, tax, total, unavailable[])
+  SF->>API: POST /checkout/intent (Bearer)
+  API->>DB: Resolve user + ensure Stripe customer
+  API->>ST: customers.create / paymentIntents.create
+  ST-->>API: clientSecret
+  API-->>SF: clientSecret
+  SF->>ST: Confirm payment via Stripe.js (Elements)
+  ST-->>SF: succeeded
+  SF->>API: POST /account/orders
+  API->>ST: paymentIntents.retrieve (verify succeeded)
+  API->>DB: Create order, items, invoice (transactional)
+  API->>API: Generate invoice PDF (pdfkit) + persist path
+  API-->>SF: Order with invoice ref
+```
+
+## 3. Data flow — admin login (with 2FA)
+
+```mermaid
+sequenceDiagram
+  participant A as Admin
+  participant BO as Backoffice
+  participant API as API
+  participant DB as PostgreSQL
+
+  A->>BO: email + password
+  BO->>API: POST /admin/auth/login
+  API->>DB: User.verifyCredentials
+  alt 2FA enrolled
+    API-->>BO: 202 { requires2fa, challengeToken (encrypted, 5 min) }
+    A->>BO: TOTP / recovery code
+    BO->>API: POST /admin/auth/verify-2fa { challengeToken, code }
+    API->>API: Decrypt challenge, verify code (otplib)
+    API->>DB: Issue access token
+    API-->>BO: { user, token }
+  else no 2FA
+    API->>DB: Issue access token
+    API-->>BO: { user, token }
+  end
+  BO->>BO: Persist token in cookie + middleware guards admin routes
+```
+
+## 4. Storage map
+
+| Concern              | Store                  | Why                                                   |
+|----------------------|------------------------|-------------------------------------------------------|
+| Relational data      | PostgreSQL             | Transactions for orders, FKs, Lucid integration       |
+| Product images       | MongoDB GridFS         | Binary blobs streamed directly to clients             |
+| Invoice / credit PDF | Local filesystem       | Generated lazily by pdfkit, served by API only        |
+| Sessions             | DB access tokens       | Bearer tokens with TTL, revocable from /logout        |
+| Locale preference    | `althea_locale` cookie | Read by `@nuxtjs/i18n`, drives RTL toggle             |
+
+## 5. Tech stack rationale
+
+### Storefront — Nuxt 4
+- SSR-first improves SEO for category and product pages.
+- Composition API + auto-imports keeps pages and composables small (`useApi`,
+  `useAuth`, `useCart`, `useStripe`) without manual boilerplate.
+- Tailwind v4 with `@theme` tokens ships fast and consistent design without a
+  component-library lock-in.
+- `@nuxtjs/i18n` provides the locale switching, browser detection and RTL/LTR
+  toggling (used for Arabic).
+- `@stripe/stripe-js` with Elements is the only canonical way to charge cards
+  while keeping PCI-DSS scope minimal.
+
+### Backoffice — Nuxt 4 + Nuxt UI v4
+- Same runtime as the storefront so the team only learns one frontend stack.
+- Nuxt UI v4 ships dashboard primitives (`UDashboardGroup`, `UDashboardSidebar`,
+  `UTable`, `UModal`, `USlideover`) which would otherwise take weeks to build.
+- Chart.js + vue-chartjs for sales analytics — small (~70 KB gzipped) and
+  trivially integrates with our SSR setup via `<ClientOnly>`.
+- TipTap for the homepage rich-text editor — chosen over a custom contentEditable
+  for proper schema, marks (bold/italic/link/color), and SSR-safe mounting.
+
+### API — AdonisJS 6
+- TypeScript-first, opinionated structure (controllers, validators, services,
+  middleware) reduces bikeshedding.
+- Lucid ORM keeps queries explicit, supports transactions and naturalSort
+  migrations. Snake_case column conventions match Postgres idioms.
+- Vine validators run at the controller boundary — schemas live next to routes
+  rather than scattered through service code.
+- `@adonisjs/auth` + `DbAccessTokensProvider` gives revocable bearer tokens out
+  of the box; we build admin 2FA on top via otplib + an encrypted challenge.
+- `@adonisjs/mail` abstracts SMTP / log drivers so dev runs without a real MTA.
+
+### Storage choices
+- **PostgreSQL** for relational guarantees on orders/invoices.
+- **MongoDB GridFS** because product images can be large and benefit from
+  chunked streaming. Keeping binaries out of Postgres simplifies backups.
+- **Local filesystem** for generated PDFs is acceptable for now; production
+  should switch to S3-compatible object storage and update
+  `invoice_generator.ts` / `credit_note_generator.ts` accordingly.
+
+## 6. Repository layout
+
+```
+althea-systems/
+├── apps/
+│   ├── api/              # AdonisJS 6 — REST API
+│   ├── backoffice/       # Nuxt 4 + Nuxt UI — admin console
+│   └── storefront/       # Nuxt 4 — public web app
+├── docs/                 # Architecture, deployment, API spec, security
+├── packages/             # (reserved) shared libs
+├── docker-compose.yml    # Postgres + Mongo for local dev
+└── pnpm-workspace.yaml
+```
+
+## 7. Cross-app contracts
+
+- All apps consume the API over HTTP and authenticate with a Bearer token issued
+  by `/auth/login` (storefront) or `/admin/auth/login` (backoffice).
+- The OpenAPI source of truth is `docs/openapi.yaml`, served by the API at
+  `/docs` (Swagger UI) and `/openapi.yaml` (raw).
+- CORS allows any origin with credentials in dev; production must pin
+  `apps/api/config/cors.ts` to the storefront and backoffice origins.

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -1,0 +1,131 @@
+# Deployment guide
+
+This is a baseline deployment recipe. Adapt to your hosting provider as needed.
+
+## Topology
+
+- **API**: Node 22 process behind Nginx / a load balancer. Public endpoint `/api`
+  or a dedicated subdomain.
+- **Storefront**: Nuxt SSR running on Node 22, behind a CDN that respects
+  `cache-control` from the SSR response.
+- **Backoffice**: Nuxt SSR or static + SSR hybrid. Locked behind the corporate
+  IP allow-list or VPN if possible.
+- **Postgres**: managed instance (RDS, Cloud SQL, etc.) with daily backups.
+- **MongoDB**: managed instance with GridFS for product images.
+- **Object storage** (recommended): S3-compatible bucket for invoice/credit-note
+  PDFs (replace `apps/api/app/services/invoice_generator.ts` storage path).
+
+## Environment
+
+API (Production):
+
+```ini
+NODE_ENV=production
+APP_KEY=<32-byte secret, openssl rand -hex 32>
+HOST=0.0.0.0
+PORT=3333
+LOG_LEVEL=info
+
+DB_HOST=...
+DB_PORT=5432
+DB_USER=...
+DB_PASSWORD=...
+DB_DATABASE=...
+MONGO_URI=mongodb+srv://...
+MONGO_DATABASE=...
+
+STOREFRONT_URL=https://shop.althea.example.com
+
+MAIL_DRIVER=smtp
+SMTP_HOST=...
+SMTP_PORT=587
+MAIL_FROM_ADDRESS=no-reply@althea.example.com
+MAIL_FROM_NAME=Althea Systems
+
+STRIPE_SECRET_KEY=sk_live_...
+STRIPE_CURRENCY=eur
+
+ADMIN_EMAIL=ops@althea.example.com
+ADMIN_PASSWORD=<rotate after first login>
+TOTP_ISSUER=Althea Backoffice
+```
+
+Storefront (Production):
+
+```ini
+NUXT_PUBLIC_API_BASE=https://api.althea.example.com
+NUXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_live_...
+```
+
+## Build
+
+```sh
+pnpm install --frozen-lockfile
+pnpm --filter api exec node ace build
+pnpm --filter storefront build
+pnpm --filter backoffice build
+```
+
+Build artefacts:
+
+- API: `apps/api/build/`
+- Storefront: `apps/storefront/.output/`
+- Backoffice: `apps/backoffice/.output/`
+
+## Run
+
+API (with PM2 or systemd):
+
+```sh
+cd apps/api/build && node bin/server.js
+```
+
+Storefront / backoffice:
+
+```sh
+node apps/storefront/.output/server/index.mjs
+node apps/backoffice/.output/server/index.mjs
+```
+
+## Database migration
+
+Always run migrations as part of the deploy step (after the build, before
+flipping traffic):
+
+```sh
+cd apps/api/build && node ace migration:run --force
+```
+
+For zero-downtime, add new columns nullable, deploy code that tolerates both
+shapes, backfill, then deploy code requiring the new shape.
+
+## Reverse proxy (Nginx skeleton)
+
+```nginx
+server {
+  listen 443 ssl http2;
+  server_name api.althea.example.com;
+  ssl_certificate     /etc/letsencrypt/live/api.althea.example.com/fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/api.althea.example.com/privkey.pem;
+
+  location / {
+    proxy_pass http://127.0.0.1:3333;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+}
+```
+
+Repeat for `shop.` (storefront) and `admin.` (backoffice). Disable HTTP and
+redirect to HTTPS on every host.
+
+## Operations
+
+- Backups: nightly logical Postgres dump + MongoDB dump. Test restore quarterly.
+- Monitoring: scrape API logs (pino) into your aggregator; alert on 5xx > 1%
+  over 5 min.
+- Stripe webhooks: not yet wired; add `/stripe/webhook` consuming
+  `payment_intent.succeeded` and reconcile against orders.
+- Secrets rotation: rotate `APP_KEY`, Stripe live key, and DB passwords on a
+  scheduled cadence (90 days).

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,0 +1,108 @@
+# Installation guide
+
+## Prerequisites
+
+- **Node.js** 22+
+- **pnpm** 10+ (`corepack enable && corepack prepare pnpm@latest --activate`)
+- **Docker** with Compose v2 (for Postgres + MongoDB)
+- A **Stripe** account (test mode is enough for dev)
+
+## 1. Clone and install
+
+```sh
+git clone https://github.com/Mega-Knight-MK3/althea-systems.git
+cd althea-systems
+pnpm install
+```
+
+## 2. Start local databases
+
+```sh
+docker compose up -d postgres mongodb
+```
+
+Postgres listens on `localhost:5432`, MongoDB on `localhost:27017`. Both ship with
+the credentials baked into `docker-compose.yml` — adjust them before any non-local
+deployment.
+
+## 3. Configure the API (`apps/api/.env`)
+
+Copy `.env.example` if present, otherwise create one with at least:
+
+```ini
+NODE_ENV=development
+PORT=3333
+APP_KEY=replace-me-with-32-bytes
+HOST=0.0.0.0
+LOG_LEVEL=info
+
+DB_HOST=127.0.0.1
+DB_PORT=5432
+DB_USER=althea
+DB_PASSWORD=althea
+DB_DATABASE=althea
+
+MONGO_URI=mongodb://127.0.0.1:27017
+MONGO_DATABASE=althea_assets
+
+STOREFRONT_URL=http://localhost:3000
+
+# Mailer — log driver writes to stdout. Switch to smtp in prod.
+MAIL_DRIVER=log
+MAIL_FROM_ADDRESS=no-reply@althea.local
+MAIL_FROM_NAME=Althea Systems
+
+# Stripe (test keys)
+STRIPE_SECRET_KEY=sk_test_...
+STRIPE_CURRENCY=eur
+
+# Admin seeder
+ADMIN_EMAIL=admin@althea.local
+ADMIN_PASSWORD=AltheaAdmin!2026
+ADMIN_FULL_NAME=Althea Admin
+TOTP_ISSUER=Althea Backoffice
+```
+
+Run migrations and seed the first admin:
+
+```sh
+pnpm --filter api exec node ace migration:run
+pnpm --filter api exec node ace db:seed
+```
+
+## 4. Configure the storefront (`apps/storefront/.env`)
+
+```ini
+NUXT_PUBLIC_API_BASE=http://localhost:3333
+NUXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_...
+```
+
+## 5. Configure the backoffice (`apps/backoffice`)
+
+The backoffice reads `NUXT_PUBLIC_API_BASE` (defaults to `http://localhost:3333`).
+Override via `apps/backoffice/.env` only if your API runs elsewhere.
+
+## 6. Run everything
+
+In three terminals (or via a process manager of your choice):
+
+```sh
+pnpm --filter api dev          # http://localhost:3333
+pnpm --filter storefront dev   # http://localhost:3000
+pnpm --filter backoffice dev   # http://localhost:3001
+```
+
+Then:
+
+- Storefront: <http://localhost:3000>
+- Backoffice: <http://localhost:3001> — login `admin@althea.local` / `AltheaAdmin!2026`
+- API docs (Swagger UI): <http://localhost:3333/docs>
+
+## Troubleshooting
+
+| Symptom                             | Fix                                                                      |
+|-------------------------------------|--------------------------------------------------------------------------|
+| `useXxx is not defined` in dev      | `rm -rf apps/<app>/.nuxt && pnpm dev` to rebuild auto-import index       |
+| 500 on `/admin/dashboard/sales`     | API not running or session expired — log out and back in                 |
+| CORS preflight blocked              | Confirm the dev origin is allowed in `apps/api/config/cors.ts`           |
+| Stripe payments stuck on "Payment"  | Backoffice Stripe key doesn't match storefront — keep them in the same account |

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,0 +1,103 @@
+# Security plan
+
+This document describes the security controls, threat model and operational
+practices for Althea Systems.
+
+## 1. Identity and session management
+
+- **Customer auth**: bearer access tokens issued by `@adonisjs/auth` via the
+  `DbAccessTokensProvider`. Default TTL is 12 hours, 30 days when "remember me"
+  is checked.
+- **Admin auth**: separate token name (`backoffice_session`), 8-hour TTL, and
+  mandatory role + active checks at the middleware boundary
+  (`apps/api/app/middleware/admin_middleware.ts`).
+- **2FA (admin)**: TOTP via `otplib` and an encrypted 5-minute challenge token
+  generated with `@adonisjs/core/services/encryption`. Recovery codes are
+  generated once, hashed with SHA-256 before storage, and consumed atomically.
+- **Password hashing**: `scrypt` via `@adonisjs/core/services/hash` with the
+  default cost. Never log or return password hashes (see `serializeAs: null`).
+- **Token revocation**: every `/logout` deletes the current row from
+  `auth_access_tokens`. Compromised tokens can be invalidated by deleting the
+  row directly.
+
+## 2. Transport and data at rest
+
+- **TLS**: production hosts must terminate TLS at Nginx / the load balancer.
+  HTTP must redirect to HTTPS.
+- **Database**: Postgres connection is restricted to the API host via SG/VPC
+  rules. Backups are encrypted at rest by the managed service.
+- **PDF storage**: invoices and credit notes live under `apps/api/storage/`
+  during dev. Production deployment must move them to S3-compatible storage with
+  bucket policies that deny public access; signed URLs for download.
+- **Secrets**: all secrets read from `.env`. The repository's `.gitignore`
+  excludes `.env*` files. Use a secret manager in production.
+
+## 3. Application-level protections
+
+| Threat               | Control                                                                 |
+|----------------------|-------------------------------------------------------------------------|
+| **SQL injection**    | All queries use Lucid query builder or parameterized raw queries; no string concatenation in SQL. |
+| **XSS (stored)**     | Vue interpolates with `{{ }}` (escaped). The TipTap rich text is sanitized to a known mark/extension set. Never use `v-html` on untrusted input. |
+| **XSS (reflected)**  | Toast/error messages display values via `{{ }}`. The chatbot/contact form runs visitor input through `{{ }}` as well. |
+| **CSRF**             | API uses bearer tokens, not cookies, so traditional CSRF doesn't apply. The admin login uses an encrypted challenge that's bound to the session that requested it. |
+| **Mass assignment**  | Lucid models populate via explicit `.merge(payload)` from Vine validators; no `request.all()` is forwarded directly. |
+| **Open redirect**    | The login redirect parameter only accepts in-app paths and is validated at the boundary in the backoffice login page. |
+| **Replay (2FA)**     | Challenge tokens have a 5-minute TTL, are encrypted with the app key and have a fixed `purpose`. Recovery codes are removed from the user's set once consumed. |
+| **Brute force**      | Pending — recommend adding `@adonisjs/limiter` to `/auth/login` and `/admin/auth/login` (5 req/min/IP) before production. |
+| **Privilege escalation** | Admin endpoints sit behind `auth + admin` middleware. The user-update validator does not accept role from the storefront flow. |
+| **CORS**             | `apps/api/config/cors.ts`: production must restrict `origin` to the storefront and backoffice hostnames. |
+
+## 4. Payments
+
+- All card data is collected via Stripe Elements; the API never sees the PAN.
+- We persist only the Stripe payment method id, brand and last four digits.
+- Stripe customer creation is lazy via `ensureStripeCustomer` so legacy users
+  get a customer the first time they save a card or pay.
+- `payment_intent` confirmation is verified server-side before creating an order
+  (status must be `succeeded`).
+
+## 5. RGPD / GDPR
+
+- Personal data lives in PostgreSQL: users, addresses, orders, contact
+  messages, chatbot sessions.
+- **Right to access**: customers see their data via `/account`. Admins can
+  export through `/admin/users/:id`.
+- **Right to erasure**: the admin user-detail page exposes a delete action that
+  permanently removes the user (cascade on FK rules and `onDelete('SET NULL')`
+  for chatbot sessions). Admin accounts cannot be deleted from the UI.
+- **Right to rectification**: customers update profile/email/password from
+  `/account`; admin can update names through the API.
+- **Data retention**: production should set retention policies (e.g. delete
+  contact messages 24 months after creation, anonymize orders after 10 years
+  for accounting compliance).
+- **Data minimization**: forms ask only for what is needed for the order. We do
+  not collect birth dates, government ids or marketing preferences by default.
+
+## 6. Logging and observability
+
+- API logs use `pino` and are JSON-structured. In production, ship them to your
+  log aggregator and never include passwords, tokens or payment data.
+- Failed mail deliveries log the recipient and link only — not the body.
+- Admin status changes on orders are persisted to `order_status_history` along
+  with the admin who made the change.
+
+## 7. Testing cadence
+
+- Pre-merge: API typecheck + Japa unit/functional suites run automatically in
+  CI (`.github/workflows/ci.yml`).
+- Pre-release: manual checklist
+  - SSO flow: customer register → verify email → login → checkout
+  - Backoffice flow: 2FA enroll → login → CRUD products + categories
+  - Stripe in test mode: 4242 4242 4242 4242 succeeds, declined card surfaces
+- Post-release: weekly automated dependency audit (`pnpm audit`) and quarterly
+  manual penetration testing of authentication, authorization and payment
+  paths.
+
+## 8. Incident response
+
+- Rotate `APP_KEY` and admin passwords; force re-login by deleting all access
+  tokens (`DELETE FROM auth_access_tokens;`).
+- Revoke compromised Stripe API keys via the Stripe dashboard and rotate
+  webhook secrets.
+- Notify users within 72 hours if their personal data is impacted (GDPR
+  Article 33).

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,634 @@
+openapi: 3.1.0
+info:
+  title: Althea Systems API
+  version: 1.0.0
+  description: |
+    REST API powering the Althea Systems storefront and backoffice. Authentication uses
+    bearer access tokens issued by AdonisJS Auth (DbAccessTokensProvider). All admin
+    endpoints require a token whose owner has `role = "admin"` and is active.
+servers:
+  - url: http://localhost:3333
+    description: Local dev
+  - url: https://api.althea.example.com
+    description: Production
+tags:
+  - name: Public
+    description: Endpoints reachable without authentication
+  - name: Auth
+    description: Customer authentication
+  - name: Admin auth
+    description: Backoffice authentication with TOTP 2FA
+  - name: Account
+    description: Authenticated customer profile, addresses, payment methods, orders
+  - name: Catalog
+    description: Categories and products
+  - name: Checkout
+    description: Pricing quotes and Stripe payment intent creation
+  - name: Contact
+    description: Public contact form and chatbot
+  - name: Admin
+    description: Backoffice resources guarded by auth + admin middleware
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: opaque
+  schemas:
+    Pagination:
+      type: object
+      properties:
+        meta:
+          type: object
+          properties:
+            total: { type: integer }
+            perPage: { type: integer }
+            currentPage: { type: integer }
+            lastPage: { type: integer }
+        data:
+          type: array
+          items: {}
+    User:
+      type: object
+      properties:
+        id: { type: integer }
+        email: { type: string, format: email }
+        fullName: { type: string, nullable: true }
+        phone: { type: string, nullable: true }
+        role: { type: string, enum: [customer, admin] }
+        emailVerifiedAt: { type: string, nullable: true, format: date-time }
+        isActive: { type: boolean }
+        createdAt: { type: string, format: date-time }
+    Token:
+      type: object
+      properties:
+        type: { type: string, example: bearer }
+        value: { type: string }
+        expiresAt: { type: string, format: date-time, nullable: true }
+    Address:
+      type: object
+      properties:
+        id: { type: integer }
+        userId: { type: integer }
+        fullName: { type: string, nullable: true }
+        street: { type: string }
+        line2: { type: string, nullable: true }
+        city: { type: string }
+        postalCode: { type: string }
+        country: { type: string }
+        isDefault: { type: boolean }
+    PaymentMethod:
+      type: object
+      properties:
+        id: { type: integer }
+        userId: { type: integer }
+        type: { type: string, example: card }
+        brand: { type: string }
+        lastFour: { type: string }
+        expMonth: { type: integer }
+        expYear: { type: integer }
+        isDefault: { type: boolean }
+    Category:
+      type: object
+      properties:
+        id: { type: integer }
+        name: { type: string }
+        slug: { type: string }
+        description: { type: string, nullable: true }
+        parentId: { type: integer, nullable: true }
+        imagePath: { type: string, nullable: true }
+        position: { type: integer }
+        isActive: { type: boolean }
+    Product:
+      type: object
+      properties:
+        id: { type: integer }
+        name: { type: string }
+        slug: { type: string }
+        description: { type: string, nullable: true }
+        price: { type: number, format: float }
+        vatRate: { type: number, format: float }
+        stock: { type: integer }
+        categoryId: { type: integer, nullable: true }
+        category: { $ref: '#/components/schemas/Category' }
+        isActive: { type: boolean }
+        sortPriority: { type: integer }
+        createdAt: { type: string, format: date-time }
+    Order:
+      type: object
+      properties:
+        id: { type: integer }
+        userId: { type: integer }
+        status:
+          type: string
+          enum: [pending, paid, processing, shipped, delivered, cancelled, refunded]
+        subtotal: { type: number }
+        tax: { type: number }
+        shippingCost: { type: number }
+        total: { type: number }
+        stripePaymentIntentId: { type: string, nullable: true }
+        placedAt: { type: string, format: date-time, nullable: true }
+        createdAt: { type: string, format: date-time }
+    Invoice:
+      type: object
+      properties:
+        id: { type: integer }
+        orderId: { type: integer }
+        invoiceNumber: { type: string }
+        subtotal: { type: number }
+        tax: { type: number }
+        total: { type: number }
+        pdfPath: { type: string, nullable: true }
+        issuedAt: { type: string, format: date-time }
+    Error:
+      type: object
+      properties:
+        message: { type: string }
+        errors:
+          type: array
+          items:
+            type: object
+            properties:
+              message: { type: string }
+              field: { type: string }
+
+paths:
+  /:
+    get:
+      tags: [Public]
+      summary: API health
+      responses:
+        '200': { description: ok }
+
+  /site-config/homepage:
+    get:
+      tags: [Public]
+      summary: Homepage configuration (carousel + intro)
+      responses:
+        '200': { description: ok }
+
+  /contact:
+    post:
+      tags: [Contact]
+      summary: Submit a contact-form message
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [name, email, subject, message]
+              properties:
+                name: { type: string }
+                email: { type: string, format: email }
+                subject: { type: string }
+                message: { type: string }
+      responses:
+        '201': { description: created }
+
+  /chatbot/sessions:
+    post:
+      tags: [Contact]
+      summary: Start a chatbot session
+      responses: { '201': { description: created } }
+  /chatbot/sessions/{id}/messages:
+    post:
+      tags: [Contact]
+      summary: Post a message to the chatbot
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: integer }
+      responses: { '201': { description: created } }
+  /chatbot/sessions/{id}/escalate:
+    post:
+      tags: [Contact]
+      summary: Escalate a chatbot session to a human agent
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: integer }
+      responses: { '202': { description: accepted } }
+
+  /auth/register:
+    post:
+      tags: [Auth]
+      summary: Create a customer account
+      responses: { '201': { description: created } }
+  /auth/login:
+    post:
+      tags: [Auth]
+      summary: Login with email/password
+      responses: { '200': { description: ok } }
+  /auth/me:
+    get:
+      tags: [Auth]
+      security: [{ bearerAuth: [] }]
+      summary: Current authenticated user
+      responses: { '200': { description: ok } }
+  /auth/refresh:
+    post:
+      tags: [Auth]
+      security: [{ bearerAuth: [] }]
+      summary: Rotate the session token
+      responses: { '200': { description: ok } }
+  /auth/logout:
+    post:
+      tags: [Auth]
+      security: [{ bearerAuth: [] }]
+      summary: Revoke current session
+      responses: { '204': { description: no content } }
+  /auth/verify-email:
+    post:
+      tags: [Auth]
+      summary: Verify a one-time email token
+      responses: { '200': { description: ok } }
+  /auth/resend-verification:
+    post:
+      tags: [Auth]
+      security: [{ bearerAuth: [] }]
+      responses: { '202': { description: accepted } }
+  /auth/forgot-password:
+    post:
+      tags: [Auth]
+      responses: { '200': { description: ok } }
+  /auth/reset-password:
+    post:
+      tags: [Auth]
+      responses: { '200': { description: ok } }
+
+  /admin/auth/login:
+    post:
+      tags: [Admin auth]
+      summary: Admin login (returns 2FA challenge if enrolled)
+      responses: { '200': { description: ok }, '202': { description: 2fa challenge required } }
+  /admin/auth/verify-2fa:
+    post:
+      tags: [Admin auth]
+      summary: Verify TOTP code or recovery code against a challenge token
+      responses: { '200': { description: ok }, '401': { description: invalid code } }
+  /admin/auth/me:
+    get:
+      tags: [Admin auth]
+      security: [{ bearerAuth: [] }]
+      responses: { '200': { description: ok }, '403': { description: not admin } }
+  /admin/auth/logout:
+    post:
+      tags: [Admin auth]
+      security: [{ bearerAuth: [] }]
+      responses: { '204': { description: no content } }
+  /admin/auth/totp/enroll:
+    post:
+      tags: [Admin auth]
+      security: [{ bearerAuth: [] }]
+      responses: { '200': { description: returns secret + QR code } }
+  /admin/auth/totp/confirm:
+    post:
+      tags: [Admin auth]
+      security: [{ bearerAuth: [] }]
+      summary: Confirm TOTP enrollment with the first valid code
+      responses: { '200': { description: ok, returns one-time recovery codes } }
+  /admin/auth/totp/disable:
+    post:
+      tags: [Admin auth]
+      security: [{ bearerAuth: [] }]
+      summary: Disable 2FA (requires password + valid code/recovery code)
+      responses: { '204': { description: no content } }
+
+  /account:
+    get:
+      tags: [Account]
+      security: [{ bearerAuth: [] }]
+      responses: { '200': { description: ok } }
+    patch:
+      tags: [Account]
+      security: [{ bearerAuth: [] }]
+      responses: { '200': { description: ok } }
+  /account/email:
+    post:
+      tags: [Account]
+      security: [{ bearerAuth: [] }]
+      responses: { '202': { description: verification email sent } }
+  /account/password:
+    post:
+      tags: [Account]
+      security: [{ bearerAuth: [] }]
+      responses: { '204': { description: no content } }
+  /account/deactivate:
+    post:
+      tags: [Account]
+      security: [{ bearerAuth: [] }]
+      responses: { '204': { description: no content } }
+  /account/addresses:
+    get: { tags: [Account], security: [{ bearerAuth: [] }], responses: { '200': { description: ok } } }
+    post: { tags: [Account], security: [{ bearerAuth: [] }], responses: { '201': { description: created } } }
+  /account/addresses/{id}:
+    patch:
+      tags: [Account]
+      security: [{ bearerAuth: [] }]
+      parameters: [{ in: path, name: id, required: true, schema: { type: integer } }]
+      responses: { '200': { description: ok } }
+    delete:
+      tags: [Account]
+      security: [{ bearerAuth: [] }]
+      parameters: [{ in: path, name: id, required: true, schema: { type: integer } }]
+      responses: { '204': { description: no content } }
+  /account/payment-methods:
+    get: { tags: [Account], security: [{ bearerAuth: [] }], responses: { '200': { description: ok } } }
+    post: { tags: [Account], security: [{ bearerAuth: [] }], responses: { '201': { description: created } } }
+  /account/payment-methods/setup-intent:
+    post:
+      tags: [Account]
+      security: [{ bearerAuth: [] }]
+      summary: Create a Stripe SetupIntent so the customer can save a card
+      responses: { '200': { description: ok } }
+  /account/payment-methods/{id}:
+    patch:
+      tags: [Account]
+      security: [{ bearerAuth: [] }]
+      parameters: [{ in: path, name: id, required: true, schema: { type: integer } }]
+      responses: { '200': { description: ok } }
+    delete:
+      tags: [Account]
+      security: [{ bearerAuth: [] }]
+      parameters: [{ in: path, name: id, required: true, schema: { type: integer } }]
+      responses: { '204': { description: no content } }
+  /account/orders:
+    get: { tags: [Account], security: [{ bearerAuth: [] }], responses: { '200': { description: ok } } }
+    post: { tags: [Account], security: [{ bearerAuth: [] }], responses: { '201': { description: created } } }
+  /account/orders/{id}:
+    get:
+      tags: [Account]
+      security: [{ bearerAuth: [] }]
+      parameters: [{ in: path, name: id, required: true, schema: { type: integer } }]
+      responses: { '200': { description: ok } }
+  /account/orders/{id}/invoice:
+    get:
+      tags: [Account]
+      security: [{ bearerAuth: [] }]
+      parameters: [{ in: path, name: id, required: true, schema: { type: integer } }]
+      responses:
+        '200':
+          description: invoice PDF
+          content:
+            application/pdf: {}
+
+  /categories:
+    get:
+      tags: [Catalog]
+      responses: { '200': { description: ok } }
+  /categories/{slug}:
+    get:
+      tags: [Catalog]
+      parameters: [{ in: path, name: slug, required: true, schema: { type: string } }]
+      responses: { '200': { description: ok }, '404': { description: not found } }
+
+  /products:
+    get:
+      tags: [Catalog]
+      summary: Public product list (active only)
+      parameters:
+        - in: query
+          name: q
+          schema: { type: string }
+        - in: query
+          name: categoryId
+          schema: { type: integer }
+        - in: query
+          name: sort
+          schema: { type: string, enum: [priority, price, date, stock, relevance, name] }
+        - in: query
+          name: page
+          schema: { type: integer, default: 1 }
+        - in: query
+          name: perPage
+          schema: { type: integer, default: 24 }
+      responses: { '200': { description: ok } }
+  /products/{slug}:
+    get:
+      tags: [Catalog]
+      parameters: [{ in: path, name: slug, required: true, schema: { type: string } }]
+      responses: { '200': { description: ok } }
+  /products/{slug}/similar:
+    get:
+      tags: [Catalog]
+      parameters: [{ in: path, name: slug, required: true, schema: { type: string } }]
+      responses: { '200': { description: ok } }
+  /products/{slug}/images:
+    get:
+      tags: [Catalog]
+      parameters: [{ in: path, name: slug, required: true, schema: { type: string } }]
+      responses: { '200': { description: ok } }
+  /images/{id}:
+    get:
+      tags: [Catalog]
+      summary: Stream a product image stored in MongoDB GridFS
+      parameters: [{ in: path, name: id, required: true, schema: { type: string } }]
+      responses: { '200': { description: image binary } }
+
+  /checkout/quote:
+    post:
+      tags: [Checkout]
+      summary: Price a cart (subtotal + tax + shipping)
+      responses: { '200': { description: ok } }
+  /checkout/intent:
+    post:
+      tags: [Checkout]
+      security: [{ bearerAuth: [] }]
+      summary: Create a Stripe PaymentIntent for the current cart
+      responses: { '200': { description: ok } }
+
+  /admin/dashboard/stats:
+    get:
+      tags: [Admin]
+      security: [{ bearerAuth: [] }]
+      responses: { '200': { description: ok } }
+  /admin/dashboard/sales:
+    get:
+      tags: [Admin]
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - in: query
+          name: range
+          schema: { type: string, enum: [7d, 5w] }
+      responses: { '200': { description: ok } }
+
+  /admin/homepage:
+    get: { tags: [Admin], security: [{ bearerAuth: [] }], responses: { '200': { description: ok } } }
+  /admin/homepage/slides:
+    put:
+      tags: [Admin]
+      security: [{ bearerAuth: [] }]
+      summary: Replace all carousel slides (max 3)
+      responses: { '200': { description: ok } }
+  /admin/homepage/intro:
+    patch:
+      tags: [Admin]
+      security: [{ bearerAuth: [] }]
+      responses: { '200': { description: ok } }
+
+  /admin/categories:
+    get: { tags: [Admin], security: [{ bearerAuth: [] }], responses: { '200': { description: ok } } }
+    post: { tags: [Admin], security: [{ bearerAuth: [] }], responses: { '201': { description: created } } }
+  /admin/categories/reorder:
+    post: { tags: [Admin], security: [{ bearerAuth: [] }], responses: { '204': { description: no content } } }
+  /admin/categories/bulk-status:
+    post: { tags: [Admin], security: [{ bearerAuth: [] }], responses: { '204': { description: no content } } }
+  /admin/categories/{id}:
+    patch:
+      tags: [Admin]
+      security: [{ bearerAuth: [] }]
+      parameters: [{ in: path, name: id, required: true, schema: { type: integer } }]
+      responses: { '200': { description: ok } }
+    delete:
+      tags: [Admin]
+      security: [{ bearerAuth: [] }]
+      parameters: [{ in: path, name: id, required: true, schema: { type: integer } }]
+      responses: { '204': { description: no content } }
+
+  /admin/products:
+    get:
+      tags: [Admin]
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - in: query
+          name: status
+          schema: { type: string, enum: [all, active, inactive] }
+      responses: { '200': { description: ok } }
+    post: { tags: [Admin], security: [{ bearerAuth: [] }], responses: { '201': { description: created } } }
+  /admin/products/{id}:
+    patch:
+      tags: [Admin]
+      security: [{ bearerAuth: [] }]
+      parameters: [{ in: path, name: id, required: true, schema: { type: integer } }]
+      responses: { '200': { description: ok } }
+    delete:
+      tags: [Admin]
+      security: [{ bearerAuth: [] }]
+      parameters: [{ in: path, name: id, required: true, schema: { type: integer } }]
+      responses: { '204': { description: no content } }
+  /admin/products/{slug}/images:
+    post:
+      tags: [Admin]
+      security: [{ bearerAuth: [] }]
+      summary: Upload a product image (multipart, MongoDB GridFS storage)
+      parameters: [{ in: path, name: slug, required: true, schema: { type: string } }]
+      responses: { '201': { description: created } }
+  /admin/products/images/{id}:
+    delete:
+      tags: [Admin]
+      security: [{ bearerAuth: [] }]
+      parameters: [{ in: path, name: id, required: true, schema: { type: string } }]
+      responses: { '204': { description: no content } }
+
+  /admin/users:
+    get:
+      tags: [Admin]
+      security: [{ bearerAuth: [] }]
+      parameters:
+        - in: query
+          name: status
+          schema: { type: string, enum: [all, active, inactive, pending] }
+      responses: { '200': { description: ok } }
+  /admin/users/{id}:
+    get:
+      tags: [Admin]
+      security: [{ bearerAuth: [] }]
+      parameters: [{ in: path, name: id, required: true, schema: { type: integer } }]
+      responses: { '200': { description: ok } }
+    patch:
+      tags: [Admin]
+      security: [{ bearerAuth: [] }]
+      parameters: [{ in: path, name: id, required: true, schema: { type: integer } }]
+      responses: { '200': { description: ok } }
+    delete:
+      tags: [Admin]
+      security: [{ bearerAuth: [] }]
+      parameters: [{ in: path, name: id, required: true, schema: { type: integer } }]
+      responses: { '204': { description: no content } }
+  /admin/users/{id}/reset-password:
+    post:
+      tags: [Admin]
+      security: [{ bearerAuth: [] }]
+      parameters: [{ in: path, name: id, required: true, schema: { type: integer } }]
+      responses: { '202': { description: reset email sent } }
+
+  /admin/orders:
+    get:
+      tags: [Admin]
+      security: [{ bearerAuth: [] }]
+      responses: { '200': { description: ok } }
+  /admin/orders/{id}:
+    get:
+      tags: [Admin]
+      security: [{ bearerAuth: [] }]
+      parameters: [{ in: path, name: id, required: true, schema: { type: integer } }]
+      responses: { '200': { description: ok } }
+  /admin/orders/{id}/status:
+    patch:
+      tags: [Admin]
+      security: [{ bearerAuth: [] }]
+      parameters: [{ in: path, name: id, required: true, schema: { type: integer } }]
+      responses: { '200': { description: ok } }
+
+  /admin/invoices:
+    get: { tags: [Admin], security: [{ bearerAuth: [] }], responses: { '200': { description: ok } } }
+  /admin/invoices/{id}/download:
+    get:
+      tags: [Admin]
+      security: [{ bearerAuth: [] }]
+      parameters: [{ in: path, name: id, required: true, schema: { type: integer } }]
+      responses: { '200': { description: invoice PDF, content: { application/pdf: {} } } }
+  /admin/invoices/{id}/resend:
+    post:
+      tags: [Admin]
+      security: [{ bearerAuth: [] }]
+      parameters: [{ in: path, name: id, required: true, schema: { type: integer } }]
+      responses: { '202': { description: email sent } }
+  /admin/credit-notes:
+    get: { tags: [Admin], security: [{ bearerAuth: [] }], responses: { '200': { description: ok } } }
+    post: { tags: [Admin], security: [{ bearerAuth: [] }], responses: { '201': { description: created } } }
+  /admin/credit-notes/{id}/download:
+    get:
+      tags: [Admin]
+      security: [{ bearerAuth: [] }]
+      parameters: [{ in: path, name: id, required: true, schema: { type: integer } }]
+      responses: { '200': { description: credit note PDF, content: { application/pdf: {} } } }
+  /admin/credit-notes/{id}/resend:
+    post:
+      tags: [Admin]
+      security: [{ bearerAuth: [] }]
+      parameters: [{ in: path, name: id, required: true, schema: { type: integer } }]
+      responses: { '202': { description: email sent } }
+
+  /admin/messages:
+    get: { tags: [Admin], security: [{ bearerAuth: [] }], responses: { '200': { description: ok } } }
+  /admin/messages/{id}:
+    get:
+      tags: [Admin]
+      security: [{ bearerAuth: [] }]
+      parameters: [{ in: path, name: id, required: true, schema: { type: integer } }]
+      responses: { '200': { description: ok } }
+  /admin/messages/{id}/read:
+    patch:
+      tags: [Admin]
+      security: [{ bearerAuth: [] }]
+      parameters: [{ in: path, name: id, required: true, schema: { type: integer } }]
+      responses: { '204': { description: no content } }
+  /admin/chatbot/sessions:
+    get: { tags: [Admin], security: [{ bearerAuth: [] }], responses: { '200': { description: ok } } }
+  /admin/chatbot/sessions/{id}:
+    get:
+      tags: [Admin]
+      security: [{ bearerAuth: [] }]
+      parameters: [{ in: path, name: id, required: true, schema: { type: integer } }]
+      responses: { '200': { description: ok } }
+  /admin/chatbot/sessions/{id}/reply:
+    post:
+      tags: [Admin]
+      security: [{ bearerAuth: [] }]
+      parameters: [{ in: path, name: id, required: true, schema: { type: integer } }]
+      responses: { '201': { description: agent reply created } }


### PR DESCRIPTION
Closes #43, closes #44, closes #45, closes #46, closes #47.

Ships the full M8 documentation and infrastructure deliverables:

- **#43 OpenAPI**: docs/openapi.yaml covers every public + admin endpoint with auth scopes, served via Swagger UI at /docs and the raw spec at /openapi.yaml.
- **#44 Architecture**: docs/ARCHITECTURE.md with mermaid diagrams (high-level topology, checkout sequence, admin login + 2FA), storage map and a tech-stack rationale.
- **#45 Install + deploy**: docs/INSTALL.md and docs/DEPLOY.md from prerequisites and dev setup through production reverse-proxy, env templates and migration cadence.
- **#46 Tests**: Japa unit + functional suites under apps/api/tests covering chatbot brain, totp service, health and Swagger routes (13 passing). New .github/workflows/ci.yml runs typecheck + tests for the API and builds for the storefront / backoffice on every PR.
- **#47 Security**: docs/SECURITY.md with the threat-by-threat control matrix, RGPD obligations, payment posture, testing cadence and incident response.