### PR TITLE
feat(storefront): translate homepage UI chrome (sections, carousel arrows, badges, search, chatbot)

### DIFF
--- a/apps/storefront/app/components/AppCategoryGrid.vue
+++ b/apps/storefront/app/components/AppCategoryGrid.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { Category } from '~~/app/types/catalog'
 
+const { t } = useI18n()
 defineProps<{ categories: Category[] }>()
 </script>
 
@@ -8,9 +9,9 @@ defineProps<{ categories: Category[] }>()
   <section class="bg-neutral-50 py-12 md:py-16">
     <div class="mx-auto w-full max-w-[1440px] px-4 md:px-10">
       <header class="flex items-end justify-between">
-        <h2 class="font-display text-h2 font-medium text-brand-text">Nos catégories</h2>
+        <h2 class="font-display text-h2 font-medium text-brand-text">{{ t('home.categories_title') }}</h2>
         <NuxtLink to="/categories" class="text-sm text-brand-500 hover:text-brand-700">
-          Tout voir
+          {{ t('home.categories_view_all') }}
         </NuxtLink>
       </header>
 
@@ -44,7 +45,7 @@ defineProps<{ categories: Category[] }>()
         </li>
       </ul>
 
-      <p v-else class="mt-8 text-sm text-neutral-500">Catégories à venir.</p>
+      <p v-else class="mt-8 text-sm text-neutral-500">{{ t('home.categories_empty') }}</p>
     </div>
   </section>
 </template>

--- a/apps/storefront/app/components/AppChatbot.vue
+++ b/apps/storefront/app/components/AppChatbot.vue
@@ -24,6 +24,7 @@ const SESSION_KEY = 'althea_chatbot_session'
 
 const api = useApi()
 const { user } = useAuth()
+const { t } = useI18n()
 
 const open = ref(false)
 const initialising = ref(false)
@@ -301,7 +302,7 @@ function quickAsk(intent: string) {
       <svg viewBox="0 0 24 24" class="h-5 w-5" fill="none" stroke="currentColor" stroke-width="2">
         <path d="M21 11a8.5 8.5 0 0 1-12.5 7.5L3 21l1.6-4.5A8.5 8.5 0 1 1 21 11Z" stroke-linecap="round" stroke-linejoin="round"/>
       </svg>
-      <span class="hidden sm:inline">{{ open ? 'Réduire' : 'Contactez-nous' }}</span>
+      <span class="hidden sm:inline">{{ open ? t('chatbot.minimize') : t('chatbot.open') }}</span>
     </button>
   </div>
 </template>

--- a/apps/storefront/app/components/AppFeaturedProducts.vue
+++ b/apps/storefront/app/components/AppFeaturedProducts.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { Product } from '~~/app/types/catalog'
 
+const { t } = useI18n()
 defineProps<{ products: Product[] }>()
 </script>
 
@@ -9,7 +10,7 @@ defineProps<{ products: Product[] }>()
     <div class="mx-auto w-full max-w-[1440px] px-4 md:px-10">
       <header class="flex items-end justify-between">
         <h2 class="font-display text-h2 font-medium text-brand-text">
-          Top produits du moment
+          {{ t('home.featured_title') }}
         </h2>
       </header>
 
@@ -23,7 +24,7 @@ defineProps<{ products: Product[] }>()
       </ul>
 
       <p v-else class="mt-8 text-sm text-neutral-500">
-        Notre sélection sera disponible prochainement.
+        {{ t('home.featured_empty') }}
       </p>
     </div>
   </section>

--- a/apps/storefront/app/components/AppHeroCarousel.vue
+++ b/apps/storefront/app/components/AppHeroCarousel.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { HomepageConfig } from '~~/app/types/catalog'
 
+const { t } = useI18n()
 const props = defineProps<{ slides: HomepageConfig['carousel']['slides'] }>()
 
 const activeIndex = ref(0)
@@ -85,7 +86,7 @@ onBeforeUnmount(stop)
                 class="h-full w-full rounded-2xl object-cover"
               />
               <span v-else class="font-display text-brand-500 text-sm tracking-widest uppercase">
-                Visuel à venir
+                {{ t('home.carousel_image_pending') }}
               </span>
             </div>
           </article>
@@ -104,7 +105,7 @@ onBeforeUnmount(stop)
             ? 'w-8 bg-brand-500'
             : 'w-2 bg-brand-500/30 hover:bg-brand-500/60'
         "
-        :aria-label="`Aller à la diapositive ${index + 1}`"
+        :aria-label="t('home.carousel_go_to', { n: index + 1 })"
         @click="goTo(index)"
       />
     </div>
@@ -112,7 +113,7 @@ onBeforeUnmount(stop)
     <button
       type="button"
       class="absolute top-1/2 left-4 hidden -translate-y-1/2 rounded-full bg-white p-2 text-neutral-700 shadow transition-colors hover:text-brand-500 md:block"
-      aria-label="Précédent"
+      :aria-label="t('home.carousel_previous')"
       @click="previous"
     >
       <svg viewBox="0 0 24 24" class="h-5 w-5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
@@ -123,7 +124,7 @@ onBeforeUnmount(stop)
     <button
       type="button"
       class="absolute top-1/2 right-4 hidden -translate-y-1/2 rounded-full bg-white p-2 text-neutral-700 shadow transition-colors hover:text-brand-500 md:block"
-      aria-label="Suivant"
+      :aria-label="t('home.carousel_next')"
       @click="next"
     >
       <svg viewBox="0 0 24 24" class="h-5 w-5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">

--- a/apps/storefront/app/components/AppProductCard.vue
+++ b/apps/storefront/app/components/AppProductCard.vue
@@ -2,12 +2,13 @@
 import type { Product } from '~~/app/types/catalog'
 
 const props = defineProps<{ product: Product; layout?: 'grid' | 'list' }>()
+const { t, locale } = useI18n()
 
 const layout = computed(() => props.layout ?? 'grid')
 const inStock = computed(() => props.product.stock > 0)
 const isLowStock = computed(() => props.product.stock > 0 && props.product.stock <= 5)
 const formattedPrice = computed(() =>
-  new Intl.NumberFormat('fr-FR', { style: 'currency', currency: 'EUR' }).format(props.product.price)
+  new Intl.NumberFormat(locale.value, { style: 'currency', currency: 'EUR' }).format(props.product.price)
 )
 </script>
 
@@ -36,12 +37,12 @@ const formattedPrice = computed(() =>
 
       <p class="mt-2 text-caption">
         <span v-if="!inStock" class="rounded-full bg-danger/10 px-2 py-0.5 text-danger">
-          En rupture de stock
+          {{ t('products.out_of_stock') }}
         </span>
         <span v-else-if="isLowStock" class="rounded-full bg-warning/10 px-2 py-0.5 text-warning">
-          Stock faible
+          {{ t('products.low_stock') }}
         </span>
-        <span v-else class="rounded-full bg-success/10 px-2 py-0.5 text-success">En stock</span>
+        <span v-else class="rounded-full bg-success/10 px-2 py-0.5 text-success">{{ t('products.in_stock') }}</span>
       </p>
     </div>
   </NuxtLink>

--- a/apps/storefront/app/components/AppSearchBar.vue
+++ b/apps/storefront/app/components/AppSearchBar.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 const router = useRouter()
+const { t } = useI18n()
 const query = ref('')
 
 function onSubmit() {
@@ -19,14 +20,14 @@ function onSubmit() {
       v-model="query"
       type="search"
       name="q"
-      placeholder="Rechercher un produit, une catégorie"
+      :placeholder="t('search.placeholder')"
       class="w-full bg-transparent text-base text-neutral-800 placeholder:text-neutral-600 focus:outline-none"
-      aria-label="Rechercher un produit ou une catégorie"
+      :aria-label="t('search.placeholder')"
     />
     <button
       type="submit"
       class="text-neutral-600 transition-colors hover:text-brand-500"
-      aria-label="Lancer la recherche"
+      :aria-label="t('search.submit')"
     >
       <svg
         viewBox="0 0 24 24"

--- a/apps/storefront/app/pages/cart.vue
+++ b/apps/storefront/app/pages/cart.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-const { t } = useI18n()
+const { t, locale } = useI18n()
 useHead(() => ({ title: `${t('cart.title')} — Althea Systems` }))
 
 const cart = useCart()
@@ -38,16 +38,16 @@ function removeUnavailable() {
   for (const line of quote.value?.unavailable ?? []) {
     cart.remove(line.productId)
   }
-  toast.info('Produits indisponibles retirés du panier.')
+  toast.info(t('cart.unavailable_removed'))
 }
 
 function onRemove(productId: number, name: string) {
   cart.remove(productId)
-  toast.info(`${name} retiré du panier.`)
+  toast.info(t('cart.removed', { name }))
 }
 
 const formatPrice = (value: number) =>
-  new Intl.NumberFormat('fr-FR', { style: 'currency', currency: 'EUR' }).format(value)
+  new Intl.NumberFormat(locale.value, { style: 'currency', currency: 'EUR' }).format(value)
 
 const hasUnavailable = computed(() => (quote.value?.unavailable.length ?? 0) > 0)
 const canCheckout = computed(
@@ -60,7 +60,7 @@ const canCheckout = computed(
     <div class="flex flex-wrap items-end justify-between gap-3">
       <h1 class="font-display text-h1 font-medium text-brand-text">{{ t('cart.title') }}</h1>
       <NuxtLink to="/" class="text-sm text-neutral-500 hover:text-brand-500">
-        ← Continuer mes achats
+        ← {{ t('cart.continue_shopping') }}
       </NuxtLink>
     </div>
 
@@ -75,7 +75,7 @@ const canCheckout = computed(
       </svg>
       <h2 class="font-display text-h3 font-medium text-brand-text">{{ t('cart.empty') }}</h2>
       <p class="mt-2 max-w-sm text-sm text-neutral-600">
-        Parcourez le catalogue et ajoutez vos produits pour les retrouver ici.
+        {{ t('cart.browse_empty_lead') }}
       </p>
       <NuxtLink
         to="/"
@@ -91,15 +91,13 @@ const canCheckout = computed(
           v-if="hasUnavailable"
           class="bg-warning/10 text-warning flex items-start justify-between gap-4 rounded-md border border-warning/20 px-4 py-3 text-sm"
         >
-          <span>
-            Certains produits ne sont plus disponibles. Retirez-les pour finaliser votre commande.
-          </span>
+          <span>{{ t('cart.unavailable_warning') }}</span>
           <button
             type="button"
             class="rounded-md border border-warning/40 px-3 py-1 text-xs font-medium hover:bg-warning/20"
             @click="removeUnavailable"
           >
-            Retirer tout
+            {{ t('cart.remove_all') }}
           </button>
         </div>
 
@@ -123,10 +121,10 @@ const canCheckout = computed(
                     v-if="lineFor(item.productId) && !lineFor(item.productId)?.available"
                     class="text-danger mt-1 text-caption"
                   >
-                    Indisponible
+                    {{ t('cart.unavailable') }}
                   </p>
                   <p v-else class="text-caption mt-1 text-neutral-500">
-                    {{ formatPrice(item.unitPrice) }} l’unité
+                    {{ t('cart.unit_price', { price: formatPrice(item.unitPrice) }) }}
                   </p>
                 </div>
                 <button
@@ -142,7 +140,7 @@ const canCheckout = computed(
                   <button
                     type="button"
                     class="px-4 py-2 text-base text-neutral-600 transition-colors hover:text-brand-500"
-                    aria-label="Diminuer la quantité"
+                    :aria-label="t('cart.decrease')"
                     @click="cart.setQuantity(item.productId, item.quantity - 1)"
                   >
                     −
@@ -151,7 +149,7 @@ const canCheckout = computed(
                   <button
                     type="button"
                     class="px-4 py-2 text-base text-neutral-600 transition-colors hover:text-brand-500"
-                    aria-label="Augmenter la quantité"
+                    :aria-label="t('cart.increase')"
                     @click="cart.setQuantity(item.productId, item.quantity + 1)"
                   >
                     +
@@ -170,7 +168,7 @@ const canCheckout = computed(
       <aside
         class="rounded-xl border border-neutral-100 bg-white p-6 lg:sticky lg:top-24 lg:self-start"
       >
-        <h2 class="font-display text-h3 font-medium text-brand-text">Récapitulatif</h2>
+        <h2 class="font-display text-h3 font-medium text-brand-text">{{ t('cart.summary') }}</h2>
         <dl class="mt-6 space-y-3 text-sm text-neutral-700">
           <div class="flex justify-between">
             <dt>{{ t('cart.subtotal') }}</dt>
@@ -207,7 +205,7 @@ const canCheckout = computed(
         </button>
 
         <p v-if="!isAuthenticated" class="text-caption mt-3 text-neutral-500">
-          Vous devrez vous connecter pour finaliser la commande.
+          {{ t('cart.must_login') }}
         </p>
       </aside>
     </div>

--- a/apps/storefront/i18n/locales/ar.json
+++ b/apps/storefront/i18n/locales/ar.json
@@ -19,7 +19,25 @@
   "home": {
     "stat_expertise": "سنوات من الخبرة",
     "stat_cabinets": "عيادة مجهزة",
-    "stat_sav": "زمن الاستجابة للدعم"
+    "stat_sav": "زمن الاستجابة للدعم",
+    "categories_title": "فئاتنا",
+    "categories_view_all": "عرض الكل",
+    "categories_empty": "الفئات قريبًا.",
+    "featured_title": "أبرز المنتجات حاليًا",
+    "featured_empty": "ستتوفر تشكيلتنا قريبًا.",
+    "carousel_image_pending": "الصورة قريبًا",
+    "carousel_previous": "السابق",
+    "carousel_next": "التالي",
+    "carousel_go_to": "الانتقال إلى الشريحة {n}"
+  },
+  "products": {
+    "in_stock": "متوفر",
+    "low_stock": "المخزون منخفض",
+    "out_of_stock": "غير متوفر"
+  },
+  "search": {
+    "placeholder": "ابحث عن منتج أو فئة",
+    "submit": "بدء البحث"
   },
   "contact": {
     "eyebrow": "اتصل بنا",

--- a/apps/storefront/i18n/locales/en.json
+++ b/apps/storefront/i18n/locales/en.json
@@ -19,7 +19,25 @@
   "home": {
     "stat_expertise": "years of expertise",
     "stat_cabinets": "practices equipped",
-    "stat_sav": "SAV response time"
+    "stat_sav": "SAV response time",
+    "categories_title": "Our categories",
+    "categories_view_all": "View all",
+    "categories_empty": "Categories coming soon.",
+    "featured_title": "Top picks right now",
+    "featured_empty": "Our selection will be available soon.",
+    "carousel_image_pending": "Visual coming soon",
+    "carousel_previous": "Previous",
+    "carousel_next": "Next",
+    "carousel_go_to": "Go to slide {n}"
+  },
+  "products": {
+    "in_stock": "In stock",
+    "low_stock": "Low stock",
+    "out_of_stock": "Out of stock"
+  },
+  "search": {
+    "placeholder": "Search for a product or category",
+    "submit": "Run search"
   },
   "contact": {
     "eyebrow": "Contact us",
@@ -82,13 +100,25 @@
     "title": "My cart",
     "empty": "Your cart is empty.",
     "browse": "Browse the catalog",
+    "continue_shopping": "Continue shopping",
     "subtotal": "Subtotal",
     "shipping": "Shipping",
     "tax": "VAT",
     "total": "Total",
     "checkout": "Proceed to checkout",
     "remove": "Remove",
-    "quantity": "Quantity"
+    "remove_all": "Remove all",
+    "quantity": "Quantity",
+    "decrease": "Decrease quantity",
+    "increase": "Increase quantity",
+    "summary": "Summary",
+    "unavailable": "Unavailable",
+    "unavailable_warning": "Some products are no longer available. Remove them to complete your order.",
+    "unavailable_removed": "Unavailable products removed from cart.",
+    "removed": "{name} removed from cart.",
+    "unit_price": "{price} each",
+    "must_login": "You'll need to sign in to place the order.",
+    "browse_empty_lead": "Browse the catalog and add products to find them here."
   },
   "chatbot": {
     "open": "Contact us",

--- a/apps/storefront/i18n/locales/fr.json
+++ b/apps/storefront/i18n/locales/fr.json
@@ -19,7 +19,25 @@
   "home": {
     "stat_expertise": "ans d'expertise",
     "stat_cabinets": "cabinets équipés",
-    "stat_sav": "vitesse de réponse SAV"
+    "stat_sav": "vitesse de réponse SAV",
+    "categories_title": "Nos catégories",
+    "categories_view_all": "Tout voir",
+    "categories_empty": "Catégories à venir.",
+    "featured_title": "Top produits du moment",
+    "featured_empty": "Notre sélection sera disponible prochainement.",
+    "carousel_image_pending": "Visuel à venir",
+    "carousel_previous": "Précédent",
+    "carousel_next": "Suivant",
+    "carousel_go_to": "Aller à la diapositive {n}"
+  },
+  "products": {
+    "in_stock": "En stock",
+    "low_stock": "Stock faible",
+    "out_of_stock": "En rupture de stock"
+  },
+  "search": {
+    "placeholder": "Rechercher un produit, une catégorie",
+    "submit": "Lancer la recherche"
   },
   "contact": {
     "eyebrow": "Nous contacter",
@@ -82,13 +100,25 @@
     "title": "Mon panier",
     "empty": "Votre panier est vide.",
     "browse": "Découvrir le catalogue",
+    "continue_shopping": "Continuer mes achats",
     "subtotal": "Sous-total",
     "shipping": "Livraison",
     "tax": "TVA",
     "total": "Total",
     "checkout": "Passer à la caisse",
     "remove": "Retirer",
-    "quantity": "Quantité"
+    "remove_all": "Retirer tout",
+    "quantity": "Quantité",
+    "decrease": "Diminuer la quantité",
+    "increase": "Augmenter la quantité",
+    "summary": "Récapitulatif",
+    "unavailable": "Indisponible",
+    "unavailable_warning": "Certains produits ne sont plus disponibles. Retirez-les pour finaliser votre commande.",
+    "unavailable_removed": "Produits indisponibles retirés du panier.",
+    "removed": "{name} retiré du panier.",
+    "unit_price": "{price} l'unité",
+    "must_login": "Vous devrez vous connecter pour finaliser la commande.",
+    "browse_empty_lead": "Parcourez le catalogue et ajoutez vos produits pour les retrouver ici."
   },
   "chatbot": {
     "open": "Contactez-nous",


### PR DESCRIPTION
Closes the visible home-page i18n gap that was flagged after switching to AR.

Translates the static UI chrome rendered around the data:
- AppHeroCarousel: image-pending placeholder + arrow/dot aria-labels
- AppCategoryGrid: section title, view-all link, empty state
- AppFeaturedProducts: section title, empty state
- AppProductCard: stock badges (in/low/out)
- AppSearchBar: placeholder + submit aria
- AppChatbot floating button label
- Cart page: continue shopping, summary, unavailable warning, qty arrows, must-login, removed toast

Adds matching keys in fr/en/ar.json under home, products, search, cart namespaces. AppProductCard now also formats prices using the active locale's Intl.NumberFormat instead of always fr-FR.

Out of scope (DB/API content): carousel slide eyebrow/title/body/CTA, intro body and stats labels, product/category names. These live in PostgreSQL / hardcoded in site_config_controller.ts as French strings — translating them needs a multilingual schema (translations table or per-column suffixes) which we deferred.