### PR TITLE
feat: multilingual carousel slides and intro body

### DIFF
--- a/apps/api/app/controllers/admin_homepage_controller.ts
+++ b/apps/api/app/controllers/admin_homepage_controller.ts
@@ -15,6 +15,7 @@ export default class AdminHomepageController {
     return {
       slides,
       introBody: intro?.value ?? '',
+      introTranslations: intro?.translations ?? {},
     }
   }
 
@@ -35,6 +36,7 @@ export default class AdminHomepageController {
             imageUrl: slide.imageUrl ?? null,
             position: i,
             isActive: slide.isActive ?? true,
+            translations: slide.translations ?? {},
           },
           { client: trx }
         )
@@ -46,14 +48,19 @@ export default class AdminHomepageController {
   }
 
   async updateIntro({ request }: HttpContext) {
-    const { body } = await request.validateUsing(updateIntroValidator)
+    const { body, translations } = await request.validateUsing(updateIntroValidator)
     const existing = await SiteSetting.find(INTRO_BODY_KEY)
     if (existing) {
       existing.value = body
+      if (translations) existing.translations = translations
       await existing.save()
     } else {
-      await SiteSetting.create({ key: INTRO_BODY_KEY, value: body })
+      await SiteSetting.create({
+        key: INTRO_BODY_KEY,
+        value: body,
+        translations: translations ?? {},
+      })
     }
-    return { introBody: body }
+    return { introBody: body, introTranslations: translations ?? {} }
   }
 }

--- a/apps/api/app/controllers/site_config_controller.ts
+++ b/apps/api/app/controllers/site_config_controller.ts
@@ -1,6 +1,11 @@
-import HomepageSlide from '#models/homepage_slide'
+import type { HttpContext } from '@adonisjs/core/http'
+import HomepageSlide, { type SlideLocaleFields } from '#models/homepage_slide'
 import SiteSetting from '#models/site_setting'
 import { INTRO_BODY_KEY } from '#controllers/admin_homepage_controller'
+
+const SUPPORTED_LOCALES = ['fr', 'en', 'ar'] as const
+type Locale = (typeof SUPPORTED_LOCALES)[number]
+const DEFAULT_LOCALE: Locale = 'fr'
 
 const FALLBACK_SLIDES = [
   {
@@ -36,35 +41,57 @@ const FALLBACK_INTRO_BODY =
   'Althea Systems accompagne les professionnels de santé avec un catalogue de matériel médical de pointe, choisi par des praticiens et soutenu par un service après-vente rapide.'
 
 export default class SiteConfigController {
-  async homepage() {
+  async homepage({ request }: HttpContext) {
+    const locale = pickLocale(request.header('accept-language'))
+
     const [dbSlides, intro] = await Promise.all([
       HomepageSlide.query().where('isActive', true).orderBy('position', 'asc'),
       SiteSetting.find(INTRO_BODY_KEY),
     ])
 
-    const slides = dbSlides.length > 0
-      ? dbSlides.map((s) => ({
-          id: s.id,
-          eyebrow: s.eyebrow ?? '',
-          title: s.title,
-          body: s.body ?? '',
-          ctaLabel: s.ctaLabel ?? '',
-          ctaUrl: s.ctaUrl ?? '',
-          imageUrl: s.imageUrl ?? '',
-        }))
-      : FALLBACK_SLIDES
+    const slides =
+      dbSlides.length > 0
+        ? dbSlides.map((s) => {
+            const localized = pickSlideTranslation(s.translations, locale)
+            return {
+              id: s.id,
+              eyebrow: localized.eyebrow ?? s.eyebrow ?? '',
+              title: localized.title ?? s.title,
+              body: localized.body ?? s.body ?? '',
+              ctaLabel: localized.ctaLabel ?? s.ctaLabel ?? '',
+              ctaUrl: s.ctaUrl ?? '',
+              imageUrl: s.imageUrl ?? '',
+            }
+          })
+        : FALLBACK_SLIDES
+
+    const introBody = intro
+      ? intro.translations?.[locale] || intro.value || FALLBACK_INTRO_BODY
+      : FALLBACK_INTRO_BODY
 
     return {
       carousel: { slides },
       intro: {
-        body: intro?.value || FALLBACK_INTRO_BODY,
-        stats: [
-          { id: 'expertise', value: '15', label: 'ans d’expertise' },
-          { id: 'cabinets', value: '2000+', label: 'cabinets équipés' },
-          { id: 'sav', value: '48h', label: 'vitesse de réponse SAV' },
-        ],
+        body: introBody,
       },
       featuredProductSlugs: [] as string[],
     }
   }
+}
+
+function pickLocale(header: string | string[] | undefined): Locale {
+  if (!header) return DEFAULT_LOCALE
+  const raw = Array.isArray(header) ? header[0] : header
+  const candidate = raw?.split(',')[0]?.split('-')[0]?.toLowerCase()
+  return SUPPORTED_LOCALES.includes(candidate as Locale)
+    ? (candidate as Locale)
+    : DEFAULT_LOCALE
+}
+
+function pickSlideTranslation(
+  translations: Record<string, SlideLocaleFields> | undefined,
+  locale: Locale
+): SlideLocaleFields {
+  if (!translations || locale === DEFAULT_LOCALE) return {}
+  return translations[locale] ?? {}
 }

--- a/apps/api/app/models/homepage_slide.ts
+++ b/apps/api/app/models/homepage_slide.ts
@@ -1,6 +1,15 @@
 import { DateTime } from 'luxon'
 import { BaseModel, column } from '@adonisjs/lucid/orm'
 
+export interface SlideLocaleFields {
+  eyebrow?: string | null
+  title?: string | null
+  body?: string | null
+  ctaLabel?: string | null
+}
+
+export type SlideTranslations = Record<string, SlideLocaleFields>
+
 export default class HomepageSlide extends BaseModel {
   @column({ isPrimary: true })
   declare id: number
@@ -28,6 +37,15 @@ export default class HomepageSlide extends BaseModel {
 
   @column()
   declare isActive: boolean
+
+  @column({
+    prepare: (value: SlideTranslations | null) => JSON.stringify(value ?? {}),
+    consume: (value: string | object | null) => {
+      if (!value) return {}
+      return typeof value === 'string' ? JSON.parse(value) : value
+    },
+  })
+  declare translations: SlideTranslations
 
   @column.dateTime({ autoCreate: true })
   declare createdAt: DateTime

--- a/apps/api/app/models/site_setting.ts
+++ b/apps/api/app/models/site_setting.ts
@@ -12,6 +12,15 @@ export default class SiteSetting extends BaseModel {
   @column()
   declare value: string
 
+  @column({
+    prepare: (value: Record<string, string> | null) => JSON.stringify(value ?? {}),
+    consume: (value: string | object | null) => {
+      if (!value) return {}
+      return typeof value === 'string' ? JSON.parse(value) : value
+    },
+  })
+  declare translations: Record<string, string>
+
   @column.dateTime({ autoCreate: true, autoUpdate: true })
   declare updatedAt: DateTime | null
 }

--- a/apps/api/app/validators/homepage.ts
+++ b/apps/api/app/validators/homepage.ts
@@ -1,5 +1,12 @@
 import vine from '@vinejs/vine'
 
+const localeFields = vine.object({
+  eyebrow: vine.string().trim().maxLength(80).nullable().optional(),
+  title: vine.string().trim().maxLength(200).nullable().optional(),
+  body: vine.string().trim().maxLength(800).nullable().optional(),
+  ctaLabel: vine.string().trim().maxLength(80).nullable().optional(),
+})
+
 const slideShape = vine.object({
   id: vine.number().positive().optional(),
   eyebrow: vine.string().trim().maxLength(80).nullable().optional(),
@@ -9,6 +16,7 @@ const slideShape = vine.object({
   ctaUrl: vine.string().trim().maxLength(255).nullable().optional(),
   imageUrl: vine.string().trim().maxLength(500).nullable().optional(),
   isActive: vine.boolean().optional(),
+  translations: vine.record(localeFields).optional(),
 })
 
 export const replaceSlidesValidator = vine.compile(
@@ -20,5 +28,6 @@ export const replaceSlidesValidator = vine.compile(
 export const updateIntroValidator = vine.compile(
   vine.object({
     body: vine.string().trim().maxLength(8000),
+    translations: vine.record(vine.string().trim().maxLength(8000)).optional(),
   })
 )

--- a/apps/api/database/migrations/1774100000001_alter_homepage_slides_add_translations.ts
+++ b/apps/api/database/migrations/1774100000001_alter_homepage_slides_add_translations.ts
@@ -1,0 +1,17 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'homepage_slides'
+
+  async up() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.jsonb('translations').notNullable().defaultTo('{}')
+    })
+  }
+
+  async down() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.dropColumn('translations')
+    })
+  }
+}

--- a/apps/api/database/migrations/1774100000002_alter_site_settings_add_translations.ts
+++ b/apps/api/database/migrations/1774100000002_alter_site_settings_add_translations.ts
@@ -1,0 +1,17 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'site_settings'
+
+  async up() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.jsonb('translations').notNullable().defaultTo('{}')
+    })
+  }
+
+  async down() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.dropColumn('translations')
+    })
+  }
+}

--- a/apps/backoffice/app/pages/homepage.vue
+++ b/apps/backoffice/app/pages/homepage.vue
@@ -1,13 +1,19 @@
 <script setup lang="ts">
-interface Slide {
-  id?: number
+type Locale = 'fr' | 'en' | 'ar'
+
+interface SlideLocaleFields {
   eyebrow: string
   title: string
   body: string
   ctaLabel: string
+}
+
+interface Slide extends SlideLocaleFields {
+  id?: number
   ctaUrl: string
   imageUrl: string
   isActive: boolean
+  translations: Record<Locale, SlideLocaleFields>
 }
 
 interface HomepagePayload {
@@ -21,12 +27,22 @@ interface HomepagePayload {
     imageUrl: string | null
     isActive: boolean
     position: number
+    translations?: Record<string, Partial<SlideLocaleFields>>
   }>
   introBody: string
+  introTranslations?: Record<string, string>
 }
 
 const api = useApi()
 const toast = useToast()
+
+const LOCALES: Array<{ value: Locale, label: string }> = [
+  { value: 'fr', label: 'Français (par défaut)' },
+  { value: 'en', label: 'English' },
+  { value: 'ar', label: 'العربية' }
+]
+
+const activeLocale = ref<Locale>('fr')
 
 const { data, refresh } = await useAsyncData<HomepagePayload>('admin-homepage', () =>
   api<HomepagePayload>('/admin/homepage')
@@ -34,6 +50,7 @@ const { data, refresh } = await useAsyncData<HomepagePayload>('admin-homepage', 
 
 const slides = ref<Slide[]>([])
 const introBody = ref('')
+const introTranslations = ref<Record<Locale, string>>({ fr: '', en: '', ar: '' })
 
 watch(data, (value) => {
   if (!value) return
@@ -46,15 +63,47 @@ watch(data, (value) => {
     ctaUrl: s.ctaUrl ?? '',
     imageUrl: s.imageUrl ?? '',
     isActive: s.isActive,
+    translations: {
+      fr: { eyebrow: '', title: '', body: '', ctaLabel: '' },
+      en: emptyTranslation(s.translations?.en),
+      ar: emptyTranslation(s.translations?.ar)
+    }
   }))
   introBody.value = value.introBody
+  introTranslations.value = {
+    fr: value.introBody,
+    en: value.introTranslations?.en ?? '',
+    ar: value.introTranslations?.ar ?? ''
+  }
 }, { immediate: true })
+
+function emptyTranslation(source?: Partial<SlideLocaleFields>): SlideLocaleFields {
+  return {
+    eyebrow: source?.eyebrow ?? '',
+    title: source?.title ?? '',
+    body: source?.body ?? '',
+    ctaLabel: source?.ctaLabel ?? ''
+  }
+}
 
 const savingSlides = ref(false)
 const savingIntro = ref(false)
 
 function newSlide(): Slide {
-  return { eyebrow: '', title: '', body: '', ctaLabel: '', ctaUrl: '', imageUrl: '', isActive: true }
+  return {
+    eyebrow: '',
+    title: '',
+    body: '',
+    ctaLabel: '',
+    ctaUrl: '',
+    imageUrl: '',
+    isActive: true,
+    translations: {
+      fr: { eyebrow: '', title: '', body: '', ctaLabel: '' },
+      en: { eyebrow: '', title: '', body: '', ctaLabel: '' },
+      ar: { eyebrow: '', title: '', body: '', ctaLabel: '' }
+    }
+  }
 }
 
 function addSlide() {
@@ -77,17 +126,52 @@ function move(index: number, direction: -1 | 1) {
   slides.value = next
 }
 
+function fieldFor(slide: Slide, field: keyof SlideLocaleFields): string {
+  if (activeLocale.value === 'fr') return slide[field]
+  return slide.translations[activeLocale.value][field]
+}
+
+function setFieldFor(slide: Slide, field: keyof SlideLocaleFields, value: string) {
+  if (activeLocale.value === 'fr') {
+    slide[field] = value
+  } else {
+    slide.translations[activeLocale.value][field] = value
+  }
+}
+
+const introBodyForLocale = computed({
+  get: () => introTranslations.value[activeLocale.value] ?? '',
+  set: (value: string) => {
+    introTranslations.value[activeLocale.value] = value
+    if (activeLocale.value === 'fr') introBody.value = value
+  }
+})
+
 async function saveSlides() {
   if (savingSlides.value) return
   if (slides.value.some((s) => !s.title.trim())) {
-    toast.add({ color: 'error', title: 'Chaque slide doit avoir un titre.' })
+    toast.add({ color: 'error', title: 'Chaque slide doit avoir un titre en français.' })
     return
   }
   savingSlides.value = true
   try {
     await api('/admin/homepage/slides', {
       method: 'PUT',
-      body: { slides: slides.value }
+      body: {
+        slides: slides.value.map((s) => ({
+          eyebrow: s.eyebrow || null,
+          title: s.title,
+          body: s.body || null,
+          ctaLabel: s.ctaLabel || null,
+          ctaUrl: s.ctaUrl || null,
+          imageUrl: s.imageUrl || null,
+          isActive: s.isActive,
+          translations: {
+            en: s.translations.en,
+            ar: s.translations.ar
+          }
+        }))
+      }
     })
     toast.add({ color: 'success', title: 'Carrousel enregistré.' })
     refresh()
@@ -102,7 +186,16 @@ async function saveIntro() {
   if (savingIntro.value) return
   savingIntro.value = true
   try {
-    await api('/admin/homepage/intro', { method: 'PATCH', body: { body: introBody.value } })
+    await api('/admin/homepage/intro', {
+      method: 'PATCH',
+      body: {
+        body: introTranslations.value.fr || introBody.value,
+        translations: {
+          en: introTranslations.value.en || '',
+          ar: introTranslations.value.ar || ''
+        }
+      }
+    })
     toast.add({ color: 'success', title: 'Texte de présentation enregistré.' })
   } catch (err) {
     toast.add({ color: 'error', title: extractMessage(err, 'Erreur lors de l\'enregistrement.') })
@@ -125,12 +218,25 @@ function extractMessage(err: unknown, fallback: string) {
   <UDashboardNavbar title="Carrousel d'accueil" />
   <div class="flex flex-col gap-4 sm:gap-6 flex-1 overflow-y-auto p-4 sm:p-6">
     <div class="space-y-6 max-w-4xl">
+      <UAlert
+        color="primary"
+        variant="subtle"
+        icon="i-lucide-languages"
+        title="Édition multilingue"
+        description="Choisissez la langue à éditer. Le français est la version par défaut, l'anglais et l'arabe sont des traductions optionnelles servies selon la langue du visiteur."
+      />
+
+      <UTabs
+        v-model="activeLocale"
+        :items="LOCALES.map((l) => ({ label: l.label, value: l.value }))"
+      />
+
       <UCard>
         <template #header>
           <div class="flex items-center justify-between gap-3">
             <div>
               <h2 class="font-semibold">Slides du carrousel</h2>
-              <p class="text-sm text-muted">3 slides maximum. Glissez les flèches pour réordonner.</p>
+              <p class="text-sm text-muted">3 slides maximum. Réordonnez avec les flèches.</p>
             </div>
             <UButton
               icon="i-lucide-plus"
@@ -162,19 +268,22 @@ function extractMessage(err: unknown, fallback: string) {
 
             <div class="grid gap-3 md:grid-cols-2">
               <UFormField label="Eyebrow">
-                <UInput v-model="slide.eyebrow" class="w-full" />
+                <UInput :model-value="fieldFor(slide, 'eyebrow')" class="w-full" @update:model-value="(v: string) => setFieldFor(slide, 'eyebrow', v)" />
               </UFormField>
-              <UFormField label="Titre" required>
-                <UInput v-model="slide.title" class="w-full" />
+              <UFormField :label="activeLocale === 'fr' ? 'Titre' : 'Titre (' + activeLocale + ')'" :required="activeLocale === 'fr'">
+                <UInput :model-value="fieldFor(slide, 'title')" class="w-full" @update:model-value="(v: string) => setFieldFor(slide, 'title', v)" />
               </UFormField>
             </div>
             <UFormField label="Corps">
-              <UTextarea v-model="slide.body" :rows="2" class="w-full" />
+              <UTextarea :model-value="fieldFor(slide, 'body')" :rows="2" class="w-full" @update:model-value="(v: string) => setFieldFor(slide, 'body', v)" />
             </UFormField>
-            <div class="grid gap-3 md:grid-cols-3">
-              <UFormField label="Texte du bouton">
-                <UInput v-model="slide.ctaLabel" class="w-full" />
-              </UFormField>
+            <UFormField label="Texte du bouton">
+              <UInput :model-value="fieldFor(slide, 'ctaLabel')" class="w-full" @update:model-value="(v: string) => setFieldFor(slide, 'ctaLabel', v)" />
+            </UFormField>
+
+            <USeparator label="Configuration partagée (toutes langues)" />
+
+            <div class="grid gap-3 md:grid-cols-2">
               <UFormField label="Lien">
                 <UInput v-model="slide.ctaUrl" class="w-full" placeholder="/categories/xxx" />
               </UFormField>
@@ -199,11 +308,11 @@ function extractMessage(err: unknown, fallback: string) {
         <template #header>
           <div>
             <h2 class="font-semibold">Texte de présentation</h2>
-            <p class="text-sm text-muted">Affiché sous le carrousel. Mise en forme : gras, italique, lien, couleurs.</p>
+            <p class="text-sm text-muted">Affiché sous le carrousel. Édité dans la langue active : <strong>{{ activeLocale }}</strong>.</p>
           </div>
         </template>
         <ClientOnly>
-          <RichTextEditor v-model="introBody" />
+          <RichTextEditor v-model="introBodyForLocale" />
           <template #fallback>
             <div class="border border-default rounded-lg p-3 min-h-32 text-sm text-muted">Chargement de l'éditeur…</div>
           </template>

--- a/apps/storefront/app/components/AppIntroSection.vue
+++ b/apps/storefront/app/components/AppIntroSection.vue
@@ -1,7 +1,14 @@
 <script setup lang="ts">
 import type { HomepageConfig } from '~~/app/types/catalog'
 
+const { t } = useI18n()
 defineProps<{ intro: HomepageConfig['intro'] }>()
+
+const stats = [
+  { id: 'expertise', value: '15', labelKey: 'home.stat_expertise' },
+  { id: 'cabinets', value: '2000+', labelKey: 'home.stat_cabinets' },
+  { id: 'sav', value: '48h', labelKey: 'home.stat_sav' }
+]
 </script>
 
 <template>
@@ -10,11 +17,11 @@ defineProps<{ intro: HomepageConfig['intro'] }>()
       <p class="text-body-lg max-w-3xl text-neutral-700">{{ intro.body }}</p>
       <dl class="mt-10 grid grid-cols-1 gap-6 md:grid-cols-3">
         <div
-          v-for="stat in intro.stats"
+          v-for="stat in stats"
           :key="stat.id"
           class="rounded-xl border border-neutral-100 p-6"
         >
-          <dt class="text-caption text-neutral-500 uppercase">{{ stat.label }}</dt>
+          <dt class="text-caption text-neutral-500 uppercase">{{ t(stat.labelKey) }}</dt>
           <dd class="font-display text-h1 mt-2 font-medium text-brand-500">{{ stat.value }}</dd>
         </div>
       </dl>

--- a/apps/storefront/app/composables/useApi.ts
+++ b/apps/storefront/app/composables/useApi.ts
@@ -1,15 +1,15 @@
 export function useApi() {
   const config = useRuntimeConfig()
   const { token, clearSession } = useAuth()
+  const { locale } = useI18n()
   return $fetch.create({
     baseURL: config.public.apiBase,
     onRequest({ options }) {
+      const headers = new Headers(options.headers as HeadersInit | undefined)
+      headers.set('Accept-Language', locale.value)
       const value = token.value?.value
-      if (value) {
-        const headers = new Headers(options.headers as HeadersInit | undefined)
-        headers.set('Authorization', `Bearer ${value}`)
-        options.headers = headers
-      }
+      if (value) headers.set('Authorization', `Bearer ${value}`)
+      options.headers = headers
     },
     onResponseError({ response }) {
       if (response.status === 401) {

--- a/apps/storefront/app/types/catalog.ts
+++ b/apps/storefront/app/types/catalog.ts
@@ -55,7 +55,6 @@ export interface HomepageConfig {
   }
   intro: {
     body: string
-    stats: Array<{ id: string; value: string; label: string }>
   }
   featuredProductSlugs: string[]
 }


### PR DESCRIPTION
Adds first-class translations for the homepage hero carousel and intro body, served by the API based on the visitor's locale.

API:
- Migrations add a JSONB translations column to homepage_slides and site_settings.
- HomepageSlide and SiteSetting models expose typed translations.
- SiteConfigController.homepage now reads Accept-Language, picks fr/en/ar with fr as fallback, and merges localized fields over the base columns.
- AdminHomepageController and validators accept a translations payload alongside the default content. Stats labels move out of the API response.

Storefront:
- useApi attaches Accept-Language from the active i18n locale on every request.
- AppIntroSection renders stats labels via i18n (home.stat_*).
- HomepageConfig type drops intro.stats.

Backoffice:
- /homepage gets a global locale switcher (Français par défaut / English / العربية). The slide editor and rich-text intro editor bind to the active locale; non-localizable fields (image URL, link, active toggle) stay shared.

Verified end-to-end with Arabic seed data: home renders eyebrow / title / body / CTA / intro body / stats labels in AR with RTL layout. Falls back to FR when a translation key is missing.

Out of scope: product and category names still come from the products/categories tables as French strings — translating them needs the same pattern but a wider migration touching the product detail and search pages, deferred to a follow-up.