### PR TITLE
feat: multilingual products and categories

### DIFF
--- a/apps/api/app/controllers/categories_controller.ts
+++ b/apps/api/app/controllers/categories_controller.ts
@@ -1,17 +1,22 @@
 import type { HttpContext } from '@adonisjs/core/http'
 import Category from '#models/category'
 import { createCategoryValidator, updateCategoryValidator } from '#validators/category'
+import { localizeNamed, pickLocale, type Locale } from '#services/locale'
 
 export default class CategoriesController {
-  async index() {
-    return Category.query().orderBy('position', 'asc').orderBy('name', 'asc')
+  async index({ request }: HttpContext) {
+    const categories = await Category.query().orderBy('position', 'asc').orderBy('name', 'asc')
+    const locale = pickLocale(request.header('accept-language'))
+    return categories.map((c) => localizeCategory(c, locale))
   }
 
-  async show({ params }: HttpContext) {
-    return Category.query()
+  async show({ params, request }: HttpContext) {
+    const category = await Category.query()
       .where('slug', params.slug)
       .preload('children', (q) => q.orderBy('position', 'asc'))
       .firstOrFail()
+    const locale = pickLocale(request.header('accept-language'))
+    return localizeCategory(category, locale)
   }
 
   async store({ request, response }: HttpContext) {
@@ -35,4 +40,22 @@ export default class CategoriesController {
     await category.delete()
     return response.noContent()
   }
+}
+
+function localizeCategory(category: Category, locale: Locale): Record<string, unknown> {
+  const { name, description } = localizeNamed(category, locale)
+  const serialized = category.serialize() as Record<string, unknown>
+  serialized.name = name
+  serialized.description = description
+  const children = serialized.children as Array<Record<string, unknown>> | undefined
+  if (Array.isArray(children) && category.children) {
+    serialized.children = category.children.map((child) => {
+      const localizedChild = localizeNamed(child, locale)
+      const childSerialized = child.serialize() as Record<string, unknown>
+      childSerialized.name = localizedChild.name
+      childSerialized.description = localizedChild.description
+      return childSerialized
+    })
+  }
+  return serialized
 }

--- a/apps/api/app/controllers/products_controller.ts
+++ b/apps/api/app/controllers/products_controller.ts
@@ -6,13 +6,15 @@ import {
   updateProductValidator,
 } from '#validators/product'
 import { listProducts } from '#services/product_search'
+import { localizeNamed, pickLocale } from '#services/locale'
 
 const SIMILAR_PRODUCT_LIMIT = 6
 
 export default class ProductsController {
   async index({ request }: HttpContext) {
     const query = await listProductsValidator.validate(request.qs())
-    return listProducts(query)
+    const result = await listProducts(query)
+    return localizePaginator(result, pickLocale(request.header('accept-language')))
   }
 
   async adminIndex({ request }: HttpContext) {
@@ -20,15 +22,20 @@ export default class ProductsController {
     return listProducts({ ...query, status: query.status ?? 'all' })
   }
 
-  async show({ params }: HttpContext) {
-    return Product.query().where('slug', params.slug).preload('category').firstOrFail()
+  async show({ params, request }: HttpContext) {
+    const product = await Product.query()
+      .where('slug', params.slug)
+      .preload('category')
+      .firstOrFail()
+    const locale = pickLocale(request.header('accept-language'))
+    return localizeProduct(product, locale)
   }
 
-  async similar({ params }: HttpContext) {
+  async similar({ params, request }: HttpContext) {
     const product = await Product.query().where('slug', params.slug).firstOrFail()
     if (!product.categoryId) return []
 
-    return Product.query()
+    const items = await Product.query()
       .where('isActive', true)
       .where('categoryId', product.categoryId)
       .whereNot('id', product.id)
@@ -37,6 +44,9 @@ export default class ProductsController {
       .orderByRaw('RANDOM()')
       .limit(SIMILAR_PRODUCT_LIMIT)
       .preload('category')
+
+    const locale = pickLocale(request.header('accept-language'))
+    return items.map((item) => localizeProduct(item, locale))
   }
 
   async store({ request, response }: HttpContext) {
@@ -59,5 +69,31 @@ export default class ProductsController {
     const product = await Product.findOrFail(params.id)
     await product.delete()
     return response.noContent()
+  }
+}
+
+function localizeProduct(product: Product, locale: ReturnType<typeof pickLocale>) {
+  const { name, description } = localizeNamed(product, locale)
+  const serialized = product.serialize() as Record<string, unknown>
+  serialized.name = name
+  serialized.description = description
+  if (serialized.category && typeof serialized.category === 'object') {
+    const cat = serialized.category as Record<string, unknown>
+    const localizedCat = localizeNamed(product.category, locale)
+    cat.name = localizedCat.name
+    cat.description = localizedCat.description
+  }
+  return serialized
+}
+
+interface PaginatedProducts {
+  all(): Product[]
+  getMeta(): unknown
+}
+
+function localizePaginator(result: PaginatedProducts, locale: ReturnType<typeof pickLocale>) {
+  return {
+    meta: result.getMeta(),
+    data: result.all().map((p) => localizeProduct(p, locale)),
   }
 }

--- a/apps/api/app/models/category.ts
+++ b/apps/api/app/models/category.ts
@@ -2,6 +2,7 @@ import { DateTime } from 'luxon'
 import { BaseModel, belongsTo, column, hasMany } from '@adonisjs/lucid/orm'
 import type { BelongsTo, HasMany } from '@adonisjs/lucid/types/relations'
 import Product from '#models/product'
+import type { NamedTranslations } from '#services/locale'
 
 export default class Category extends BaseModel {
   @column({ isPrimary: true })
@@ -27,6 +28,15 @@ export default class Category extends BaseModel {
 
   @column()
   declare isActive: boolean
+
+  @column({
+    prepare: (value: NamedTranslations | null) => JSON.stringify(value ?? {}),
+    consume: (value: string | object | null) => {
+      if (!value) return {}
+      return typeof value === 'string' ? JSON.parse(value) : value
+    },
+  })
+  declare translations: NamedTranslations
 
   @column.dateTime({ autoCreate: true })
   declare createdAt: DateTime

--- a/apps/api/app/models/product.ts
+++ b/apps/api/app/models/product.ts
@@ -2,6 +2,7 @@ import { DateTime } from 'luxon'
 import { BaseModel, belongsTo, column } from '@adonisjs/lucid/orm'
 import type { BelongsTo } from '@adonisjs/lucid/types/relations'
 import Category from '#models/category'
+import type { NamedTranslations } from '#services/locale'
 
 export default class Product extends BaseModel {
   @column({ isPrimary: true })
@@ -35,6 +36,15 @@ export default class Product extends BaseModel {
 
   @column()
   declare sortPriority: number
+
+  @column({
+    prepare: (value: NamedTranslations | null) => JSON.stringify(value ?? {}),
+    consume: (value: string | object | null) => {
+      if (!value) return {}
+      return typeof value === 'string' ? JSON.parse(value) : value
+    },
+  })
+  declare translations: NamedTranslations
 
   @column.dateTime({ autoCreate: true })
   declare createdAt: DateTime

--- a/apps/api/app/services/locale.ts
+++ b/apps/api/app/services/locale.ts
@@ -1,0 +1,33 @@
+export const SUPPORTED_LOCALES = ['fr', 'en', 'ar'] as const
+export type Locale = (typeof SUPPORTED_LOCALES)[number]
+export const DEFAULT_LOCALE: Locale = 'fr'
+
+export function pickLocale(header: string | string[] | undefined): Locale {
+  if (!header) return DEFAULT_LOCALE
+  const raw = Array.isArray(header) ? header[0] : header
+  const candidate = raw?.split(',')[0]?.split('-')[0]?.toLowerCase()
+  return SUPPORTED_LOCALES.includes(candidate as Locale)
+    ? (candidate as Locale)
+    : DEFAULT_LOCALE
+}
+
+export interface NamedLocaleFields {
+  name?: string | null
+  description?: string | null
+}
+
+export type NamedTranslations = Partial<Record<Locale, NamedLocaleFields>>
+
+export function localizeNamed<T extends { name: string; description: string | null; translations?: NamedTranslations | null }>(
+  row: T,
+  locale: Locale
+): { name: string; description: string | null } {
+  if (locale === DEFAULT_LOCALE) {
+    return { name: row.name, description: row.description }
+  }
+  const t = row.translations?.[locale]
+  return {
+    name: t?.name?.trim() ? t.name : row.name,
+    description: t?.description?.trim() ? t.description : row.description,
+  }
+}

--- a/apps/api/app/validators/category.ts
+++ b/apps/api/app/validators/category.ts
@@ -7,6 +7,11 @@ const slug = vine
   .maxLength(160)
   .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/)
 
+const namedTranslation = vine.object({
+  name: vine.string().trim().maxLength(120).nullable().optional(),
+  description: vine.string().trim().maxLength(2000).nullable().optional(),
+})
+
 export const createCategoryValidator = vine.compile(
   vine.object({
     name: vine.string().trim().minLength(2).maxLength(120),
@@ -16,6 +21,7 @@ export const createCategoryValidator = vine.compile(
     imagePath: vine.string().trim().maxLength(255).optional(),
     position: vine.number().withoutDecimals().min(0).optional(),
     isActive: vine.boolean().optional(),
+    translations: vine.record(namedTranslation).optional(),
   })
 )
 
@@ -38,6 +44,7 @@ export const updateCategoryValidator = vine.withMetaData<{ categoryId: number }>
     imagePath: vine.string().trim().maxLength(255).nullable().optional(),
     position: vine.number().withoutDecimals().min(0).optional(),
     isActive: vine.boolean().optional(),
+    translations: vine.record(namedTranslation).optional(),
   })
 )
 

--- a/apps/api/app/validators/product.ts
+++ b/apps/api/app/validators/product.ts
@@ -9,6 +9,11 @@ const slug = vine
 
 const vatRate = vine.number().min(0).max(50)
 
+const namedTranslation = vine.object({
+  name: vine.string().trim().maxLength(255).nullable().optional(),
+  description: vine.string().trim().maxLength(8000).nullable().optional(),
+})
+
 export const createProductValidator = vine.compile(
   vine.object({
     name: vine.string().trim().minLength(2).maxLength(255),
@@ -20,6 +25,7 @@ export const createProductValidator = vine.compile(
     categoryId: vine.number().positive().optional(),
     isActive: vine.boolean().optional(),
     sortPriority: vine.number().withoutDecimals().min(0).optional(),
+    translations: vine.record(namedTranslation).optional(),
   })
 )
 
@@ -44,6 +50,7 @@ export const updateProductValidator = vine.withMetaData<{ productId: number }>()
     categoryId: vine.number().positive().nullable().optional(),
     isActive: vine.boolean().optional(),
     sortPriority: vine.number().withoutDecimals().min(0).optional(),
+    translations: vine.record(namedTranslation).optional(),
   })
 )
 

--- a/apps/api/database/migrations/1774200000001_alter_products_add_translations.ts
+++ b/apps/api/database/migrations/1774200000001_alter_products_add_translations.ts
@@ -1,0 +1,17 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'products'
+
+  async up() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.jsonb('translations').notNullable().defaultTo('{}')
+    })
+  }
+
+  async down() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.dropColumn('translations')
+    })
+  }
+}

--- a/apps/api/database/migrations/1774200000002_alter_categories_add_translations.ts
+++ b/apps/api/database/migrations/1774200000002_alter_categories_add_translations.ts
@@ -1,0 +1,17 @@
+import { BaseSchema } from '@adonisjs/lucid/schema'
+
+export default class extends BaseSchema {
+  protected tableName = 'categories'
+
+  async up() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.jsonb('translations').notNullable().defaultTo('{}')
+    })
+  }
+
+  async down() {
+    this.schema.alterTable(this.tableName, (table) => {
+      table.dropColumn('translations')
+    })
+  }
+}

--- a/apps/backoffice/app/components/CategoryForm.vue
+++ b/apps/backoffice/app/components/CategoryForm.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { AdminCategory } from '~/composables/useApiTypes'
+import type { AdminCategory, LocaleCode, NamedTranslations } from '~/composables/useApiTypes'
 
 interface Props {
   category?: AdminCategory | null
@@ -13,6 +13,25 @@ const api = useApi()
 const router = useRouter()
 const toast = useToast()
 
+const LOCALES: Array<{ value: LocaleCode, label: string }> = [
+  { value: 'fr', label: 'Français (par défaut)' },
+  { value: 'en', label: 'English' },
+  { value: 'ar', label: 'العربية' }
+]
+
+const activeLocale = ref<LocaleCode>('fr')
+
+interface LocaleFields {
+  name: string
+  description: string
+}
+
+const initialTranslations = (source?: NamedTranslations | null): Record<LocaleCode, LocaleFields> => ({
+  fr: { name: '', description: '' },
+  en: { name: source?.en?.name ?? '', description: source?.en?.description ?? '' },
+  ar: { name: source?.ar?.name ?? '', description: source?.ar?.description ?? '' }
+})
+
 const state = reactive({
   name: props.category?.name ?? '',
   slug: props.category?.slug ?? '',
@@ -20,7 +39,8 @@ const state = reactive({
   parentId: props.category?.parentId ?? null as number | null,
   imagePath: props.category?.imagePath ?? '',
   position: props.category?.position ?? 0,
-  isActive: props.category?.isActive ?? true
+  isActive: props.category?.isActive ?? true,
+  translations: initialTranslations(props.category?.translations)
 })
 const submitting = ref(false)
 
@@ -44,6 +64,22 @@ watch(
   }
 )
 
+const nameValue = computed({
+  get: () => activeLocale.value === 'fr' ? state.name : state.translations[activeLocale.value].name,
+  set: (value: string) => {
+    if (activeLocale.value === 'fr') state.name = value
+    else state.translations[activeLocale.value].name = value
+  }
+})
+
+const descriptionValue = computed({
+  get: () => activeLocale.value === 'fr' ? state.description : state.translations[activeLocale.value].description,
+  set: (value: string) => {
+    if (activeLocale.value === 'fr') state.description = value
+    else state.translations[activeLocale.value].description = value
+  }
+})
+
 async function submit() {
   if (submitting.value) return
   submitting.value = true
@@ -55,7 +91,11 @@ async function submit() {
       parentId: state.parentId ?? null,
       imagePath: state.imagePath || null,
       position: state.position,
-      isActive: state.isActive
+      isActive: state.isActive,
+      translations: {
+        en: { name: state.translations.en.name, description: state.translations.en.description },
+        ar: { name: state.translations.ar.name, description: state.translations.ar.description }
+      }
     }
     if (props.category) {
       const updated = await api<AdminCategory>(`/admin/categories/${props.category.id}`, { method: 'PATCH', body })
@@ -85,17 +125,22 @@ function extractMessage(err: unknown, fallback: string) {
 
 <template>
   <UForm :state="state" class="space-y-6" @submit.prevent="submit">
+    <UTabs v-model="activeLocale" :items="LOCALES.map((l) => ({ label: l.label, value: l.value }))" />
+
     <div class="grid gap-4 md:grid-cols-2">
-      <UFormField label="Nom" required>
-        <UInput v-model="state.name" class="w-full" />
+      <UFormField :label="activeLocale === 'fr' ? 'Nom' : 'Nom (' + activeLocale + ')'" :required="activeLocale === 'fr'">
+        <UInput v-model="nameValue" class="w-full" />
       </UFormField>
       <UFormField label="Slug" required>
-        <UInput v-model="state.slug" class="w-full" />
+        <UInput v-model="state.slug" :disabled="activeLocale !== 'fr'" class="w-full" />
       </UFormField>
     </div>
-    <UFormField label="Description">
-      <UTextarea v-model="state.description" :rows="3" class="w-full" />
+    <UFormField :label="activeLocale === 'fr' ? 'Description' : 'Description (' + activeLocale + ')'">
+      <UTextarea v-model="descriptionValue" :rows="3" class="w-full" />
     </UFormField>
+
+    <USeparator label="Configuration partagée (toutes langues)" />
+
     <div class="grid gap-4 md:grid-cols-3">
       <UFormField label="Catégorie parente">
         <USelect v-model="state.parentId" :items="parentItems" class="w-full" />

--- a/apps/backoffice/app/components/ProductForm.vue
+++ b/apps/backoffice/app/components/ProductForm.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { AdminCategory, AdminProduct } from '~/composables/useApiTypes'
+import type { AdminCategory, AdminProduct, LocaleCode, NamedTranslations } from '~/composables/useApiTypes'
 
 interface Props {
   product?: AdminProduct | null
@@ -13,6 +13,19 @@ const api = useApi()
 const router = useRouter()
 const toast = useToast()
 
+const LOCALES: Array<{ value: LocaleCode, label: string }> = [
+  { value: 'fr', label: 'Français (par défaut)' },
+  { value: 'en', label: 'English' },
+  { value: 'ar', label: 'العربية' }
+]
+
+const activeLocale = ref<LocaleCode>('fr')
+
+interface LocaleFields {
+  name: string
+  description: string
+}
+
 interface FormState {
   name: string
   slug: string
@@ -23,7 +36,14 @@ interface FormState {
   categoryId: number | null
   isActive: boolean
   sortPriority: number
+  translations: Record<LocaleCode, LocaleFields>
 }
+
+const initialTranslations = (source?: NamedTranslations | null): Record<LocaleCode, LocaleFields> => ({
+  fr: { name: '', description: '' },
+  en: { name: source?.en?.name ?? '', description: source?.en?.description ?? '' },
+  ar: { name: source?.ar?.name ?? '', description: source?.ar?.description ?? '' }
+})
 
 const state = reactive<FormState>({
   name: props.product?.name ?? '',
@@ -34,7 +54,8 @@ const state = reactive<FormState>({
   stock: props.product?.stock ?? 0,
   categoryId: props.product?.categoryId ?? null,
   isActive: props.product?.isActive ?? false,
-  sortPriority: props.product?.sortPriority ?? 0
+  sortPriority: props.product?.sortPriority ?? 0,
+  translations: initialTranslations(props.product?.translations)
 })
 
 const submitting = ref(false)
@@ -57,12 +78,7 @@ const vatItems = [
 ]
 
 function slugify(value: string) {
-  return value
-    .toLowerCase()
-    .normalize('NFD')
-    .replace(/[̀-ͯ]/g, '')
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/(^-|-$)/g, '')
+  return value.toLowerCase().normalize('NFD').replace(/[̀-ͯ]/g, '').replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '')
 }
 
 watch(
@@ -73,6 +89,22 @@ watch(
     }
   }
 )
+
+const nameValue = computed({
+  get: () => activeLocale.value === 'fr' ? state.name : state.translations[activeLocale.value].name,
+  set: (value: string) => {
+    if (activeLocale.value === 'fr') state.name = value
+    else state.translations[activeLocale.value].name = value
+  }
+})
+
+const descriptionValue = computed({
+  get: () => activeLocale.value === 'fr' ? state.description : state.translations[activeLocale.value].description,
+  set: (value: string) => {
+    if (activeLocale.value === 'fr') state.description = value
+    else state.translations[activeLocale.value].description = value
+  }
+})
 
 async function submit() {
   if (submitting.value) return
@@ -87,13 +119,14 @@ async function submit() {
       stock: state.stock,
       categoryId: state.categoryId ?? null,
       isActive: state.isActive,
-      sortPriority: state.sortPriority
+      sortPriority: state.sortPriority,
+      translations: {
+        en: { name: state.translations.en.name, description: state.translations.en.description },
+        ar: { name: state.translations.ar.name, description: state.translations.ar.description }
+      }
     }
     if (props.product) {
-      const updated = await api<AdminProduct>(`/admin/products/${props.product.id}`, {
-        method: 'PATCH',
-        body
-      })
+      const updated = await api<AdminProduct>(`/admin/products/${props.product.id}`, { method: 'PATCH', body })
       toast.add({ color: 'success', title: 'Produit mis à jour.' })
       emit('saved', updated)
     } else {
@@ -120,18 +153,22 @@ function extractMessage(err: unknown, fallback: string) {
 
 <template>
   <UForm :state="state" class="space-y-6" @submit.prevent="submit">
+    <UTabs v-model="activeLocale" :items="LOCALES.map((l) => ({ label: l.label, value: l.value }))" />
+
     <div class="grid gap-4 md:grid-cols-2">
-      <UFormField label="Nom" required>
-        <UInput v-model="state.name" class="w-full" />
+      <UFormField :label="activeLocale === 'fr' ? 'Nom' : 'Nom (' + activeLocale + ')'" :required="activeLocale === 'fr'">
+        <UInput v-model="nameValue" class="w-full" />
       </UFormField>
       <UFormField label="Slug" required>
-        <UInput v-model="state.slug" class="w-full" />
+        <UInput v-model="state.slug" :disabled="activeLocale !== 'fr'" class="w-full" />
       </UFormField>
     </div>
 
-    <UFormField label="Description">
-      <UTextarea v-model="state.description" :rows="4" class="w-full" />
+    <UFormField :label="activeLocale === 'fr' ? 'Description' : 'Description (' + activeLocale + ')'">
+      <UTextarea v-model="descriptionValue" :rows="4" class="w-full" />
     </UFormField>
+
+    <USeparator label="Configuration partagée (toutes langues)" />
 
     <div class="grid gap-4 md:grid-cols-3">
       <UFormField label="Prix HT" required>

--- a/apps/backoffice/app/composables/useApiTypes.ts
+++ b/apps/backoffice/app/composables/useApiTypes.ts
@@ -1,3 +1,12 @@
+export type LocaleCode = 'fr' | 'en' | 'ar'
+
+export interface NamedTranslation {
+  name?: string | null
+  description?: string | null
+}
+
+export type NamedTranslations = Partial<Record<LocaleCode, NamedTranslation>>
+
 export interface Paginated<T> {
   meta: {
     total: number
@@ -23,6 +32,7 @@ export interface AdminCategory {
   position: number
   isActive: boolean
   productCount?: number
+  translations?: NamedTranslations | null
 }
 
 export interface AdminUser {
@@ -185,4 +195,5 @@ export interface AdminProduct {
   sortPriority: number
   createdAt: string
   updatedAt: string | null
+  translations?: NamedTranslations | null
 }


### PR DESCRIPTION
Extends the multilingual pattern from #84 to product and category content.

API:
- Migrations add a JSONB translations column on products and categories.
- A shared services/locale.ts centralises Locale, pickLocale (from Accept-Language) and localizeNamed.
- Models expose typed translations with prepare/consume serialisers.
- Validators accept a translations record.
- ProductsController.index/show/similar and CategoriesController.index/show now read Accept-Language and merge fr/en/ar with fr as fallback. Index returns { meta, data } with each row's name and description swapped for the locale variant; preloaded category and child rows are localized too.

Backoffice:
- AdminProduct and AdminCategory types carry translations.
- ProductForm and CategoryForm gain a top-level locale switcher (Français par défaut / English / العربية). Name and description bind to the active locale; slug, price, stock, parent, image and status stay shared.

Verified: API returns AR product names + category name + descriptions when Accept-Language: ar is sent. Storefront homepage now shows the seeded AR product cards (سماعة طبية كارديولوجي III, جهاز قياس ضغط الدم برو X) and category (سماعات طبية).