### PR TITLE
fix(storefront): refresh data on language switch

### DIFF
--- a/apps/storefront/app/plugins/i18n-direction.client.ts
+++ b/apps/storefront/app/plugins/i18n-direction.client.ts
@@ -1,5 +1,8 @@
 export default defineNuxtPlugin((nuxtApp) => {
-  const i18n = nuxtApp.$i18n as { locale: { value: string }, locales: { value: Array<{ code: string, dir?: string }> } }
+  const i18n = nuxtApp.$i18n as {
+    locale: { value: string }
+    locales: { value: Array<{ code: string, dir?: string }> }
+  }
 
   const apply = (code: string) => {
     const meta = i18n.locales.value.find((l) => l.code === code)
@@ -9,5 +12,11 @@ export default defineNuxtPlugin((nuxtApp) => {
   }
 
   apply(i18n.locale.value)
-  watch(() => i18n.locale.value, (next) => apply(next))
+  watch(
+    () => i18n.locale.value,
+    async (next) => {
+      apply(next)
+      await refreshNuxtData()
+    }
+  )
 })


### PR DESCRIPTION
useApi attaches Accept-Language at request time, but useAsyncData caches results by key. Switching locale only flipped t() values; carousel, intro and product cards stayed in the previous language until a full reload. The i18n direction plugin now also calls refreshNuxtData() after the locale changes, so every server-fetched payload is refetched against the new Accept-Language header. Verified end-to-end via the AR↔FR toggle.